### PR TITLE
Small Tweaks

### DIFF
--- a/compiler/cx-compiler-typechecker/src/casting.rs
+++ b/compiler/cx-compiler-typechecker/src/casting.rs
@@ -110,7 +110,7 @@ pub(crate) fn add_implicit_cast(expr: &mut CXExpr, from_type: CXType, to_type: C
 }
 
 pub(crate) fn alg_bin_op_coercion(env: &mut TypeEnvironment, op: CXBinOp,
-                                  lhs: &mut Box<CXExpr>, rhs: &mut Box<CXExpr>)
+                                  lhs: &mut CXExpr, rhs: &mut CXExpr)
                                   -> Option<CXType> {
     let l_type = coerce_value(env, lhs)?;
     let r_type = coerce_value(env, rhs)?;
@@ -203,7 +203,14 @@ pub(crate) fn binop_type(op: &CXBinOp, pointer_inner: Option<&CXType>, lhs: &CXT
             Some(lhs.clone())
         },
         
-        CXBinOp::ArrayIndex => pointer_inner.cloned(),
+        CXBinOp::ArrayIndex => {
+            Some(
+                CXType {
+                    specifiers: pointer_inner?.specifiers,
+                    kind: CXTypeKind::MemoryAlias(Box::new(pointer_inner?.clone()))
+                }
+            )
+        },
 
         CXBinOp::LAnd | CXBinOp::LOr |
         CXBinOp::Less | CXBinOp::Greater | 

--- a/compiler/cx-compiler-typechecker/src/checker.rs
+++ b/compiler/cx-compiler-typechecker/src/checker.rs
@@ -118,22 +118,6 @@ fn type_check_inner(env: &mut TypeEnvironment, expr: &mut CXExpr) -> Option<CXTy
         CXExprKind::BinOp { lhs, rhs, op: CXBinOp::Access } =>
             typecheck_access(env, lhs.as_mut(), rhs.as_mut()),
 
-        CXExprKind::BinOp { lhs, rhs, op: CXBinOp::ArrayIndex } => {
-            let lhs = coerce_value(env, lhs)?;
-            implicit_coerce(env, rhs, CXTypeKind::Integer { bytes: 8, signed: true }.to_val_type())?;
-
-            let CXTypeKind::PointerTo(inner) = lhs.intrinsic_type(&env.type_map).cloned()? else {
-                log_error!("TYPE ERROR: Array index operator can only be applied to pointers, found: {lhs}");
-            };
-            
-            Some(
-                CXType::new(
-                    lhs.specifiers,
-                    CXTypeKind::MemoryAlias(inner.clone())
-                )
-            )
-        },
-
         CXExprKind::BinOp { lhs, rhs, op: CXBinOp::MethodCall } => {
             let mut lhs_type = coerce_mem_ref(env, lhs)?;
 

--- a/compiler/cx-data-bytecode/src/types.rs
+++ b/compiler/cx-data-bytecode/src/types.rs
@@ -15,7 +15,7 @@ pub enum BCTypeKind {
     Unsigned { bytes: u8 },
     Float { bytes: u8 },
     Pointer,
-    
+
     Struct { name: String, fields: Vec<(String, BCType)> },
     Union { name: String, fields: Vec<(String, BCType)> },
 

--- a/example_code/full_programs/lotto09.cx
+++ b/example_code/full_programs/lotto09.cx
@@ -26,6 +26,12 @@ void lotto(int *a)
 		numbers[r] = 1;
 	}
 
+//	for ( x=0; x<BALLS; x++ )
+//    {
+//        if( numbers[x] )
+//            printf("%d ", x+1);
+//    }
+
 	y = 0;
 	for( x=0; x<BALLS; x++ )
 	{
@@ -94,11 +100,14 @@ int main()
 
 	/* obtain the total and the average */
 	total = 0;
-	for( x=0; x<tally; x++ )
+	for( x=0; x<tally; x++ ) {
 		total = total + results[x];		    /* add up all the values */
 
+		printf("results[%d] = %d\n", x, results[x]); /* print each result */
+	}
+
 	/* reporting statements */
-    printf("(%d/%d)\n", total, tally);
+    printf("(%ld/%ld)\n", total, tally);
 
 	return(0);
 }


### PR DESCRIPTION
This pull request includes changes to the type-checking and casting logic in the compiler, as well as updates to example code and argument parsing. The most important changes focus on improving pointer handling, refining type-checking error messages, and modifying default behavior for output files.

### Compiler Improvements

#### Pointer Handling and Casting:
* Updated `alg_bin_op_coercion` to pass inner pointer types directly to `ptr_int_binop_coercion`, improving type safety and clarity in pointer-integer binary operations (`compiler/cx-compiler-typechecker/src/casting.rs`).
* Modified `add_implicit_cast` to cast to a pointer type when handling array index operations (`compiler/cx-compiler-typechecker/src/casting.rs`).
* Enhanced `binop_type` for `CXBinOp::ArrayIndex` to return a `MemoryAlias` type, ensuring proper handling of pointer dereferencing (`compiler/cx-compiler-typechecker/src/casting.rs`).

#### Type-Checking Enhancements:
* Added detailed error messages for invalid dereference and assignment operations, improving debugging and error clarity (`compiler/cx-compiler-typechecker/src/checker.rs`). [[1]](diffhunk://#diff-1459dd1aeccba0855aadf57bd8e6467949cf2d7087801f5cd0b47767f76d8582R56) [[2]](diffhunk://#diff-1459dd1aeccba0855aadf57bd8e6467949cf2d7087801f5cd0b47767f76d8582R104)
* Removed redundant type-checking logic for array indexing, as this is now handled in the updated casting logic (`compiler/cx-compiler-typechecker/src/checker.rs`).

### Miscellaneous Updates

#### Argument Parsing:
* Changed the default output file name from the input file's base name to a fixed `a.out`, simplifying the behavior for users (`compiler/cx/src/args.rs`).

#### Example Code:
* Commented out unused code in `lotto09.cx` and added debug print statements in the `main` function to aid in understanding program flow (`example_code/full_programs/lotto09.cx`). [[1]](diffhunk://#diff-278dab1d459f9b010579e76fa437de55b66d8245b7382857c2dcac6e5f3125f5R29-R34) [[2]](diffhunk://#diff-278dab1d459f9b010579e76fa437de55b66d8245b7382857c2dcac6e5f3125f5L97-R110)