### PR TITLE
CLI Fixes and Codegen Refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "compiler/cx",
     "compiler/cx-exec-pipeline",
+    "compiler/cx-exec-data",
     "compiler/cx-data-ast",
     "compiler/cx-data-bytecode",
     "compiler/cx-compiler-ast",
@@ -12,5 +13,5 @@ members = [
     "compiler/cx-backend-cranelift",
     "compiler/cx-backend-llvm",
     "compiler/cx-lsp",
-    "compiler/cx-util", "compiler/cx-exec-data",
+    "compiler/cx-util",
 ]

--- a/compiler/cx-backend-cranelift/src/inst_calling.rs
+++ b/compiler/cx-backend-cranelift/src/inst_calling.rs
@@ -43,7 +43,7 @@ pub(crate) fn prepare_method_call<'a>(
         .collect::<Vec<_>>();
 
     if prototype.return_type.is_structure() {
-        let type_size = prototype.return_type.size();
+        let type_size = prototype.return_type.fixed_size();
         let temp_buffer = allocate_variable(context, type_size as u32, None)?;
 
         params.insert(0, temp_buffer);

--- a/compiler/cx-backend-cranelift/src/routines.rs
+++ b/compiler/cx-backend-cranelift/src/routines.rs
@@ -5,7 +5,6 @@ use cranelift::prelude::{FunctionBuilder, InstBuilder, StackSlotData, StackSlotK
 use cranelift_module::{DataDescription, DataId, Module};
 use cranelift_object::ObjectModule;
 use cx_data_ast::lex::token::OperatorType;
-use cx_data_ast::parse::value_type::{get_type_size, CXTypeKind, CXType};
 use crate::FunctionState;
 
 pub(crate) fn allocate_variable(context: &mut FunctionState, bytes: u32, initial_value: Option<Value>) -> Option<Value> {

--- a/compiler/cx-backend-llvm/src/lib.rs
+++ b/compiler/cx-backend-llvm/src/lib.rs
@@ -149,8 +149,6 @@ pub fn bytecode_aot_codegen(
     global_state.module.verify().unwrap_or_else(|err| panic!("Module verification failed with error: {:#?}", err));
     global_state.module.set_triple(&TargetMachine::get_default_triple());
     
-    // println!("{}", global_state.module.print_to_string().to_string_lossy());
-    
     global_state.module
         .run_passes(
             pass_manager_str,

--- a/compiler/cx-compiler-bytecode/src/aux_routines.rs
+++ b/compiler/cx-compiler-bytecode/src/aux_routines.rs
@@ -29,7 +29,7 @@ pub(crate) fn get_struct_field(
             });
         }
         
-        offset += field_type.size();
+        offset += field_type.fixed_size();
     }
     
     None

--- a/compiler/cx-compiler-bytecode/src/implicit_cast.rs
+++ b/compiler/cx-compiler-bytecode/src/implicit_cast.rs
@@ -165,7 +165,7 @@ pub(crate) fn implicit_cast(
         CXCastType::IntToFloat => {
             builder.add_instruction(
                 VirtualInstruction::IntToFloat {
-                    from: builder.convert_cx_type(from_type)?,
+                    from: builder.convert_fixed_cx_type(from_type)?,
                     value,
                 },
                 to_type.clone()
@@ -175,7 +175,7 @@ pub(crate) fn implicit_cast(
         CXCastType::FloatToInt => {
             builder.add_instruction(
                 VirtualInstruction::FloatToInt {
-                    from: builder.convert_cx_type(from_type)?,
+                    from: builder.convert_fixed_cx_type(from_type)?,
                     value,
                 },
                 to_type.clone()

--- a/compiler/cx-data-bytecode/src/format.rs
+++ b/compiler/cx-data-bytecode/src/format.rs
@@ -77,11 +77,11 @@ impl Display for ValueID {
 impl Display for VirtualInstruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            VirtualInstruction::Allocate { size } => {
-                write!(f, "alloca {size}")
+            VirtualInstruction::Allocate { size, alignment } => {
+                write!(f, "alloca {size} (alignment: {})", alignment)
             },
-            VirtualInstruction::VariableAllocate { size } => {
-                write!(f, "variable_alloca {size}")
+            VirtualInstruction::VariableAllocate { size, alignment } => {
+                write!(f, "variable_alloca {size} (alignment: {})", size)
             },
             VirtualInstruction::FunctionParameter { param_index } => {
                 write!(f, "parameter {param_index}")
@@ -334,6 +334,9 @@ impl Display for BCTypeKind {
             },
 
             BCTypeKind::Unit => write!(f, "()"),
+            BCTypeKind::VariableSized { size, alignment } => {
+                write!(f, "variable_sized (size: {}, alignment: {})", size, alignment)
+            },
         }
     }
 }

--- a/compiler/cx-data-bytecode/src/lib.rs
+++ b/compiler/cx-data-bytecode/src/lib.rs
@@ -76,11 +76,13 @@ pub enum VirtualInstruction {
     },
     
     VariableAllocate {
-        size: ValueID
+        size: ValueID,
+        alignment: u8,
     },
 
     Allocate {
-        size: usize
+        size: usize,
+        alignment: u8,
     },
 
     Load {

--- a/compiler/cx-exec-data/Cargo.toml
+++ b/compiler/cx-exec-data/Cargo.toml
@@ -3,4 +3,7 @@ name = "cx-exec-data"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+backend-llvm = []
+
 [dependencies]

--- a/compiler/cx-exec-data/src/lib.rs
+++ b/compiler/cx-exec-data/src/lib.rs
@@ -9,20 +9,18 @@ pub enum OptimizationLevel {
     Ofast,
 }
 
+#[cfg(feature = "backend-llvm")]
+#[derive(Default, Debug, Clone, Copy)]
+pub enum CompilerBackend {
+    #[default]
+    LLVM,
+    Cranelift
+}
+
 #[cfg(not(feature = "backend-llvm"))]
 #[derive(Default, Debug, Clone, Copy)]
 pub enum CompilerBackend {
     #[default]
     Cranelift,
-
-    LLVM
-}
-
-#[cfg(feature = "backend-llvm")]
-#[derive(Default, Debug, Clone, Copy)]
-pub enum CompilerBackend {
-    Cranelift,
-
-    #[default]
     LLVM
 }

--- a/compiler/cx-exec-pipeline/Cargo.toml
+++ b/compiler/cx-exec-pipeline/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [features]
 backend-llvm = ["dep:cx-backend-llvm"]
-backend-cranelift = ["dep:cx-backend-cranelift"]
 
 [dependencies]
 
@@ -19,5 +18,5 @@ cx-exec-data = { path = "../cx-exec-data" }
 cx-data-ast = { path = "../cx-data-ast" }
 cx-data-bytecode = { path = "../cx-data-bytecode" }
 cx-backend-llvm = { path = "../cx-backend-llvm", optional = true }
-cx-backend-cranelift = { path = "../cx-backend-cranelift", optional = true }
+cx-backend-cranelift = { path = "../cx-backend-cranelift"}
 cx-util = { path = "../cx-util" }

--- a/compiler/cx-exec-pipeline/src/pipeline.rs
+++ b/compiler/cx-exec-pipeline/src/pipeline.rs
@@ -176,7 +176,7 @@ impl CompilerPipeline {
         self
     }
     
-    pub fn emit_type_defs(mut self) -> Self {
+    pub fn emit_type_defs(self) -> Self {
         let (_, types, public_types, _) = match &self.pipeline_stage {
             PipelineStage::TypesAndDependences(lexed, types, public_types, dependencies) => (lexed, types, public_types, dependencies),
             _ => panic!("PIPELINE ERROR: Cannot emit type definitions without types and dependencies!"),
@@ -188,7 +188,7 @@ impl CompilerPipeline {
         self
     }
     
-    pub fn emit_function_defs(mut self) -> Self {
+    pub fn emit_function_defs(self) -> Self {
         let parsed = match &self.pipeline_stage {
             PipelineStage::Parsed(parsed) => parsed,
             _ => panic!("PIPELINE ERROR: Cannot emit function definitions without types and dependencies!"),
@@ -262,7 +262,7 @@ impl CompilerPipeline {
         Some(ast)
     }
     
-    pub fn codegen(mut self) -> Self {
+    pub fn codegen(self) -> Self {
         match self.backend {
             CompilerBackend::LLVM => self.llvm_codegen(),
             CompilerBackend::Cranelift => self.cranelift_codegen(),
@@ -290,7 +290,7 @@ impl CompilerPipeline {
     }
 
     #[cfg(not(feature = "backend-llvm"))]
-    fn llvm_codegen(mut self) -> Self {
+    fn llvm_codegen(self) -> Self {
         panic!("LLVM backend is not enabled, but was selected!")
     }
 

--- a/compiler/cx/Cargo.toml
+++ b/compiler/cx/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.0.0"
 edition = "2021"
 
 [features]
-default = ["cx-exec-pipeline/backend-cranelift"]
-backend-llvm = ["cx-exec-pipeline/backend-llvm"]
+backend-llvm = ["cx-exec-data/backend-llvm", "cx-exec-pipeline/backend-llvm"]
 
 [dependencies]
-cx-exec-pipeline = { path = "../cx-exec-pipeline", default-features = false, features = ["backend-llvm", "backend-cranelift"] }
+cx-exec-pipeline = { path = "../cx-exec-pipeline" }
 cx-exec-data = { path = "../cx-exec-data" }

--- a/compiler/cx/src/args.rs
+++ b/compiler/cx/src/args.rs
@@ -34,10 +34,10 @@ pub fn print_help() {
 pub fn parse_args() -> Result<AppArgs, String> {
     let args = std::env::args().collect::<Vec<String>>();
     let mut input_file = None;
-    let mut output_file = None;
-    let mut backend = CompilerBackend::Cranelift;
-    let mut optimization_level = OptimizationLevel::O0;
-
+    let mut output_file = "a.out".to_string(); // Default output file
+    let mut backend = Default::default();
+    let mut optimization_level = Default::default();
+    
     let mut args_iter = args.iter().skip(1);
 
     if args_iter.len() == 0 {
@@ -62,7 +62,7 @@ pub fn parse_args() -> Result<AppArgs, String> {
             "-Ofast" => optimization_level = OptimizationLevel::Ofast,
             "-o" => {
                 if let Some(path) = args_iter.next() {
-                    output_file = Some(path.clone());
+                    output_file = path.clone();
                 } else {
                     return Err("-o flag requires an output file path".to_string());
                 }
@@ -72,7 +72,7 @@ pub fn parse_args() -> Result<AppArgs, String> {
             }
             _ => {
                 if input_file.is_some() {
-                    return Err("Multiple input files specified".to_string());
+                    return Err("Multiple input files not current supported".to_string());
                 }
                 input_file = Some(arg.clone());
             }
@@ -84,9 +84,6 @@ pub fn parse_args() -> Result<AppArgs, String> {
     if !input_file.ends_with(".cx") {
         return Err("Input file must have a .cx extension".to_string());
     }
-
-    let default_output_file = String::from("a.out");
-    let output_file = output_file.unwrap_or(default_output_file);
 
     Ok(AppArgs {
         input_file,


### PR DESCRIPTION
This pull request introduces several updates across multiple files to improve type handling, enhance functionality, and ensure consistency in the codebase. The changes primarily focus on replacing dynamic size calculations with fixed size calculations, improving type conversion logic, and adding support for alignment in memory allocation. Below is a categorized summary of the most important changes:

### Type Handling Improvements:
* Replaced calls to `size()` with `fixed_size()` across several files, ensuring more consistent handling of type sizes in functions like `prepare_method_call` and `codegen_instruction` (`compiler/cx-backend-cranelift/src/inst_calling.rs`, `compiler/cx-backend-cranelift/src/instruction.rs`). [[1]](diffhunk://#diff-ebd99ff224dcbfc28a924f48e99dac3c073553feae92464ee505102143861397L46-R46) [[2]](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183L135-R135) [[3]](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183L234-R234) [[4]](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183L436-R436) [[5]](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183L656-R656)

### Type Conversion Enhancements:
* Introduced `convert_fixed_type` and `convert_fixed_type_kind` functions to handle fixed-size type conversions, replacing the older `convert_cx_type` and `convert_cx_type_kind` functions. This ensures better handling of variable-length arrays and other complex types (`compiler/cx-compiler-bytecode/src/cx_maps.rs`). [[1]](diffhunk://#diff-c6dc9fa367ae95c39651d9cedf477e9715a46d79e5c067761738e3c7a3da111bL152-R168) [[2]](diffhunk://#diff-c6dc9fa367ae95c39651d9cedf477e9715a46d79e5c067761738e3c7a3da111bL192-R250) [[3]](diffhunk://#diff-c6dc9fa367ae95c39651d9cedf477e9715a46d79e5c067761738e3c7a3da111bL212-R271)

### Memory Allocation Enhancements:
* Added support for `alignment` in memory allocation instructions for both Cranelift and LLVM backends. This ensures proper alignment of allocated memory in virtual instructions (`compiler/cx-backend-cranelift/src/instruction.rs`, `compiler/cx-backend-llvm/src/instruction.rs`). [[1]](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183L18-R24) [[2]](diffhunk://#diff-757e36b5940f4511ca03fd1b946a8927c3bbae5d3e966d863a0543e45a6d017cL31-R49) [[3]](diffhunk://#diff-757e36b5940f4511ca03fd1b946a8927c3bbae5d3e966d863a0543e45a6d017cL61-R67)

### Code Cleanup and Consistency:
* Removed unused imports and deprecated functions, such as `get_type_size`, to streamline the codebase and reduce redundancy (`compiler/cx-backend-cranelift/src/routines.rs`, `compiler/cx-compiler-bytecode/src/instruction_gen.rs`). [[1]](diffhunk://#diff-3cbd83ebbcf1d235f33e23b96e7a94911f4e16eb1c36299cc06640335bbebdf4L8) [[2]](diffhunk://#diff-01d319ffc91453a826ad60fdf8dedf89cae7311426e747a831115aa165058656L3-R9)

### Miscellaneous:
* Updated error messages and panic messages for better clarity, such as in the Cranelift backend's dynamic stack allocation error (`compiler/cx-backend-cranelift/src/instruction.rs`).… layer and fixed some issues with the CLI / build system not choosing the correct default backend.