### PR TITLE
Bugfixing and NSW Restriction on Signed Operations

### DIFF
--- a/compiler/cx-backend-llvm/src/arithmetic.rs
+++ b/compiler/cx-backend-llvm/src/arithmetic.rs
@@ -6,7 +6,8 @@ use crate::typing::{any_to_basic_type, bc_llvm_type};
 
 pub(crate) fn generate_ptr_binop<'a>(
     global_state: &GlobalState<'a>, function_state: &FunctionState<'a>,
-    ptr_type: &BCType, left_value: AnyValueEnum<'a>, right_value: AnyValueEnum<'a>, op: BCPtrBinOp
+    ptr_type: &BCType, left_value: AnyValueEnum<'a>, right_value: AnyValueEnum<'a>, 
+    op: BCPtrBinOp
 ) -> Option<CodegenValue<'a>> {
     let ptr_type = bc_llvm_type(global_state, ptr_type)?;
 
@@ -18,9 +19,11 @@ pub(crate) fn generate_ptr_binop<'a>(
                         .expect("Expected a basic type for pointer addition");
 
                     function_state.builder
-                        .build_in_bounds_gep(basic_type,
-                                             left_value.into_pointer_value(), &[right_value.into_int_value()],
-                                             crate::instruction::inst_num().as_str())
+                        .build_in_bounds_gep(
+                            basic_type,
+                            left_value.into_pointer_value(), &[right_value.into_int_value()],
+                            crate::instruction::inst_num().as_str()
+                        )
                         .ok()?
                         .as_any_value_enum()
                 }
@@ -34,9 +37,11 @@ pub(crate) fn generate_ptr_binop<'a>(
                         .as_any_value_enum();
 
                     function_state.builder
-                        .build_in_bounds_gep(basic_type,
-                                             left_value.into_pointer_value(), &[negative.into_int_value()],
-                                             crate::instruction::inst_num().as_str())
+                        .build_in_bounds_gep(
+                            basic_type,
+                            left_value.into_pointer_value(), &[negative.into_int_value()],
+                            crate::instruction::inst_num().as_str()
+                        )
                         .ok()?
                         .as_any_value_enum()
                 }

--- a/compiler/cx-backend-llvm/src/instruction.rs
+++ b/compiler/cx-backend-llvm/src/instruction.rs
@@ -408,8 +408,18 @@ pub(crate) fn generate_instruction<'a>(
                     .get_value()
                     .into_int_value();
                 
+                let signed = match block_instruction.value.type_.kind {
+                    BCTypeKind::Signed { .. } => true,
+                    BCTypeKind::Unsigned { .. } => false,
+                    _ => unreachable!("Invalid type for IntegerUnOp"), // Unsupported type for IntegerUnOp
+                };
+                
                 CodegenValue::Value(
                     match op {
+                        BCIntUnOp::NEG if signed => function_state.builder
+                            .build_int_nsw_neg(value, inst_num().as_str())
+                            .ok()?
+                            .as_any_value_enum(),
                         BCIntUnOp::NEG => function_state.builder
                             .build_int_neg(value, inst_num().as_str())
                             .ok()?
@@ -427,7 +437,6 @@ pub(crate) fn generate_instruction<'a>(
                             )
                             .ok()?
                             .as_any_value_enum(),
-                        _ => return None, // Unsupported operation for IntegerUnOp
                     }
                 )
             },

--- a/compiler/cx-backend-llvm/src/instruction.rs
+++ b/compiler/cx-backend-llvm/src/instruction.rs
@@ -435,13 +435,21 @@ pub(crate) fn generate_instruction<'a>(
             VirtualInstruction::IntegerBinOp { left, right, op } => {
                 let left = function_state
                     .get_val_ref(left)?
-                    .get_value();
+                    .get_value()
+                    .into_int_value();
                 
                 let right = function_state
                     .get_val_ref(right)?
-                    .get_value();
+                    .get_value()
+                    .into_int_value();
+                
+                let signed = match block_instruction.value.type_.kind {
+                    BCTypeKind::Signed { .. } => true,
+                    BCTypeKind::Unsigned { .. } => false,
+                    _ => return None, // Unsupported type for IntegerBinOp
+                };
 
-                generate_int_binop(global_state, function_state, left, right, *op)?
+                generate_int_binop(global_state, function_state, left, right, *op, signed)?
             },
             
             VirtualInstruction::FloatUnOp { value, op } => {

--- a/compiler/cx-compiler-bytecode/src/cx_maps.rs
+++ b/compiler/cx-compiler-bytecode/src/cx_maps.rs
@@ -260,10 +260,15 @@ pub(crate) fn convert_fixed_type_kind(cx_type_map: &CXTypeMap, cx_type_kind: &CX
             CXTypeKind::Float { bytes } =>
                 BCTypeKind::Float { bytes: *bytes },
 
-            CXTypeKind::Array { .. } |
             CXTypeKind::Function { .. } |
             CXTypeKind::PointerTo(_) =>
                 BCTypeKind::Pointer,
+            
+            CXTypeKind::Array { _type, size } =>
+                BCTypeKind::Array {
+                    element: Box::new(convert_fixed_type(cx_type_map, _type)?),
+                    size: *size
+                },
             
             CXTypeKind::MemoryAlias(inner) => {
                 match inner.intrinsic_type(cx_type_map)? {

--- a/compiler/cx-compiler-typechecker/src/checker.rs
+++ b/compiler/cx-compiler-typechecker/src/checker.rs
@@ -392,7 +392,6 @@ fn coerce_mem_ref(
             }.into_expr(start_index, end_index);
         }
     }
-    
 
     type_check_traverse(env, expr).cloned()
 }

--- a/compiler/cx-data-bytecode/src/format.rs
+++ b/compiler/cx-data-bytecode/src/format.rs
@@ -314,6 +314,9 @@ impl Display for BCTypeKind {
             BCTypeKind::Float { bytes } => write!(f, "f{}", bytes * 8),
             BCTypeKind::Pointer => write!(f, "*"),
 
+            BCTypeKind::Array { element, size } => {
+                write!(f, "[{}; {}]", element, size)
+            },
             BCTypeKind::Struct { fields, .. } => {
                 let fields = fields
                     .iter()

--- a/compiler/cx-data-bytecode/src/types.rs
+++ b/compiler/cx-data-bytecode/src/types.rs
@@ -13,6 +13,7 @@ pub enum BCTypeKind {
     Float { bytes: u8 },
     Pointer,
 
+    Array { element: Box<BCType>, size: usize },
     Struct { name: String, fields: Vec<(String, BCType)> },
     Union { name: String, fields: Vec<(String, BCType)> },
     
@@ -57,6 +58,8 @@ impl BCType {
             BCTypeKind::Unsigned { bytes } => *bytes as usize,
             BCTypeKind::Float { bytes } => *bytes as usize,
             BCTypeKind::Pointer => 8, // TODO: make this configurable
+            BCTypeKind::Array { element, size } =>
+                element.fixed_size() * size,
             BCTypeKind::Struct { fields, .. }
                 => fields.iter()
                         .map(|(_, field)| field.fixed_size())
@@ -79,6 +82,7 @@ impl BCType {
             BCTypeKind::Unsigned { bytes } => *bytes,
             BCTypeKind::Float { bytes } => *bytes,
             BCTypeKind::Pointer => 8, // TODO: make this configurable
+            BCTypeKind::Array { element, .. } => element.alignment(),
             BCTypeKind::Struct { fields, .. }
                 => fields.iter().map(|(_, field)| field.alignment()).max().unwrap_or(1),
             BCTypeKind::Union { fields, .. }

--- a/example_code/full_programs/fast_fib.cx
+++ b/example_code/full_programs/fast_fib.cx
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+long fibonacci(long n) {
+    if (n <= 1) {
+        return n;
+    }
+
+    int a = 0;
+    int b = 1;
+    int c = 0;
+    for (int i = 2; i <= n; i++) {
+        c = a + b;
+        a = b;
+        b = c;
+    }
+
+    return b;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        printf("Usage: %s <number>\n", argv[0]);
+        return 1;
+    }
+
+    int amt = atoi(argv[1]);
+
+    if (amt < 0) {
+        printf("Please enter a non-negative integer.\n");
+        return 1;
+    }
+
+    int result = fibonacci(amt);
+    printf("Fibonacci of %d is %d\n", amt, result);
+}


### PR DESCRIPTION
This pull request introduces several changes across multiple components of the compiler, focusing on enhancements to integer and pointer operations, type handling, and the addition of array support in the bytecode system. It also includes a new example program and minor fixes. Below is a summary of the most important changes:

### Enhancements to Arithmetic and Instruction Handling
* Updated `generate_int_binop` to support signed integer operations (e.g., signed addition, subtraction, and multiplication) by introducing a `signed` parameter. [[1]](diffhunk://#diff-229e9b967cdbc4747c2522d8713a0ae2914d1b65621d9fdad71851e7012f7b33L106-R134) [[2]](diffhunk://#diff-229e9b967cdbc4747c2522d8713a0ae2914d1b65621d9fdad71851e7012f7b33L291-R306)
* Modified `generate_instruction` to handle signed integer unary and binary operations by determining the signedness of the type. [[1]](diffhunk://#diff-757e36b5940f4511ca03fd1b946a8927c3bbae5d3e966d863a0543e45a6d017cR411-R422) [[2]](diffhunk://#diff-757e36b5940f4511ca03fd1b946a8927c3bbae5d3e966d863a0543e45a6d017cL430-R461)

### Improvements to Type Handling
* Added support for arrays in the bytecode system by introducing a new `Array` variant in `BCTypeKind`. This includes size and alignment calculations, as well as formatting for display. [[1]](diffhunk://#diff-870cc287e876ce9243b00bb8de70cce044f6d48a834a8174b00bfc00be1bbbfcR16) [[2]](diffhunk://#diff-870cc287e876ce9243b00bb8de70cce044f6d48a834a8174b00bfc00be1bbbfcR61-R62) [[3]](diffhunk://#diff-870cc287e876ce9243b00bb8de70cce044f6d48a834a8174b00bfc00be1bbbfcR85) [[4]](diffhunk://#diff-8031674e5c560ea0aa2d46b117e5989099e483d14e89f73bb50915569afa004bR317-R319)
* Enhanced type coercion in the type checker by passing the `TypeEnvironment` to `add_implicit_cast` to update the expression type map. [[1]](diffhunk://#diff-a5f3f9f2aa4d882217eac327f4ab80bde3b77df16e6b206d16e4791fc3a8d8a3L77-R77) [[2]](diffhunk://#diff-a5f3f9f2aa4d882217eac327f4ab80bde3b77df16e6b206d16e4791fc3a8d8a3L92-R114) [[3]](diffhunk://#diff-a5f3f9f2aa4d882217eac327f4ab80bde3b77df16e6b206d16e4791fc3a8d8a3L140-R142) [[4]](diffhunk://#diff-a5f3f9f2aa4d882217eac327f4ab80bde3b77df16e6b206d16e4791fc3a8d8a3L164-R164) [[5]](diffhunk://#diff-a5f3f9f2aa4d882217eac327f4ab80bde3b77df16e6b206d16e4791fc3a8d8a3L173-R173) [[6]](diffhunk://#diff-a5f3f9f2aa4d882217eac327f4ab80bde3b77df16e6b206d16e4791fc3a8d8a3L191-R192)

### Code Style and Refactoring
* Improved formatting of `build_in_bounds_gep` calls in `generate_ptr_binop` for better readability. [[1]](diffhunk://#diff-229e9b967cdbc4747c2522d8713a0ae2914d1b65621d9fdad71851e7012f7b33L21-R26) [[2]](diffhunk://#diff-229e9b967cdbc4747c2522d8713a0ae2914d1b65621d9fdad71851e7012f7b33L37-R44)
* Removed unnecessary blank lines in `coerce_mem_ref` for cleaner code.

### Example Program Addition
* Added a new example program, `fast_fib.cx`, which calculates Fibonacci numbers using an iterative approach. This demonstrates the compiler's capabilities with standard C-like constructs.