### PR TITLE
Phi Node, Small Bugfixing, and Better Code Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.cx-types
 *.cx-functions
 *.o
+*.out

--- a/compiler/cx-backend-cranelift/src/codegen.rs
+++ b/compiler/cx-backend-cranelift/src/codegen.rs
@@ -7,10 +7,10 @@ use cranelift::prelude::{FunctionBuilder, FunctionBuilderContext, Signature};
 use cranelift_module::{FuncId, Linkage, Module};
 use cx_util::format::dump_data;
 use std::collections::HashMap;
-use cx_data_bytecode::{BCFunctionPrototype, BytecodeFunction, ValueID, VirtualInstruction};
+use cx_data_bytecode::{BCFunctionPrototype, BytecodeFunction, ValueID};
 
 pub(crate) fn codegen_fn_prototype(global_state: &mut GlobalState, prototype: &BCFunctionPrototype) -> Option<()> {
-    let sig = prepare_function_sig(&mut global_state.object_module, &prototype)?;
+    let sig = prepare_function_sig(&mut global_state.object_module, prototype)?;
 
     let id = global_state.object_module
         .declare_function(prototype.name.as_str(), Linkage::Preemptible, &sig)
@@ -39,8 +39,8 @@ pub(crate) fn codegen_function(global_state: &mut GlobalState, func_id: FuncId, 
 
         function_ids: &global_state.function_ids,
 
-        type_map: &global_state.type_map,
-        fn_map: &global_state.fn_map,
+        type_map: global_state.type_map,
+        fn_map: global_state.fn_map,
 
         variable_table: VariableTable::new(),
         block_map: Vec::new(),
@@ -79,7 +79,7 @@ pub(crate) fn codegen_function(global_state: &mut GlobalState, func_id: FuncId, 
         }
 
         for (value_id, instr) in fn_block.body.iter().enumerate() {
-            if let Some(val) = codegen_instruction(&mut context, &instr) {
+            if let Some(val) = codegen_instruction(&mut context, instr) {
                 context.variable_table.insert(
                     ValueID {
                         block_id: block_id as u32,

--- a/compiler/cx-backend-cranelift/src/inst_calling.rs
+++ b/compiler/cx-backend-cranelift/src/inst_calling.rs
@@ -59,7 +59,7 @@ pub(crate) fn get_method_return(
     context.builder.inst_results(inst)
         .first()
         .cloned()
-        .map(|res| CodegenValue::Value(res))
+        .map(CodegenValue::Value)
 }
 
 pub(crate) fn get_func_ref(

--- a/compiler/cx-backend-cranelift/src/lib.rs
+++ b/compiler/cx-backend-cranelift/src/lib.rs
@@ -5,7 +5,6 @@ use cranelift::prelude::isa::TargetFrontendConfig;
 use cranelift::prelude::{settings, Block, FunctionBuilder, Value};
 use cranelift_module::{DataId, FuncId};
 use cranelift_object::{ObjectBuilder, ObjectModule};
-use cx_data_ast::parse::ast::{CXFunctionMap, CXTypeMap};
 use cx_data_bytecode::{BCFunctionMap, BCFunctionPrototype, BCTypeMap, ProgramBytecode, ValueID};
 use cx_util::log_error;
 use crate::codegen::{codegen_fn_prototype, codegen_function};
@@ -32,7 +31,7 @@ impl CodegenValue {
         match self {
             CodegenValue::Value(value) => *value,
 
-            _ => panic!("Expected Value, got: {:?}", self)
+            _ => panic!("Expected Value, got: {self:?}")
         }
     }
 
@@ -40,14 +39,14 @@ impl CodegenValue {
         match self {
             CodegenValue::FunctionID { id, .. } => *id,
 
-            _ => panic!("Expected FunctionID, got: {:?}", self)
+            _ => panic!("Expected FunctionID, got: {self:?}")
         }
     }
 
     pub(crate) fn as_func_name(&self) -> &str {
         match self {
             CodegenValue::FunctionID { fn_name, .. } => fn_name.as_str(),
-            _ => panic!("Expected FunctionID, got: {:?}", self)
+            _ => panic!("Expected FunctionID, got: {self:?}")
         }
     }
 }
@@ -125,7 +124,7 @@ pub fn bytecode_aot_codegen(ast: &ProgramBytecode, output: &str) -> Option<()> {
         global_state.global_strs.push(global_val);
     }
 
-    for (_, fn_prototype) in &ast.fn_map {
+    for fn_prototype in ast.fn_map.values() {
         codegen_fn_prototype(&mut global_state, fn_prototype);
     }
 
@@ -150,7 +149,7 @@ pub fn bytecode_aot_codegen(ast: &ProgramBytecode, output: &str) -> Option<()> {
     std::fs::create_dir_all(output_path.parent().unwrap()).expect("Failed to create output directory");
     std::fs::write(output, obj.emit().unwrap()).expect("Failed to write object file");
 
-    println!("Successfully generated object file to {}", output);
+    println!("Successfully generated object file to {output}");
 
     Some(())
 }

--- a/compiler/cx-backend-cranelift/src/routines.rs
+++ b/compiler/cx-backend-cranelift/src/routines.rs
@@ -37,7 +37,7 @@ pub(crate) fn signed_bin_op(builder: &mut FunctionBuilder, op: OperatorType, lhs
             OperatorType::LessEqual => builder.ins().icmp(ir::condcodes::IntCC::SignedLessThanOrEqual, lhs, rhs),
             OperatorType::Greater => builder.ins().icmp(ir::condcodes::IntCC::SignedGreaterThan, lhs, rhs),
             OperatorType::GreaterEqual => builder.ins().icmp(ir::condcodes::IntCC::SignedGreaterThanOrEqual, lhs, rhs),
-            _ => panic!("Unimplemented operator {:?}", op)
+            _ => panic!("Unimplemented operator {op:?}")
         }
     )
 }
@@ -49,7 +49,7 @@ pub(crate) fn string_literal(object_module: &mut ObjectModule, str: &str) -> Dat
     ).unwrap();
 
     let mut str_data = str.to_owned().into_bytes();
-    str_data.push('\0' as u8);
+    str_data.push(b'\0');
 
     let mut data = DataDescription::new();
     data.define(str_data.into_boxed_slice());

--- a/compiler/cx-backend-cranelift/src/value_type.rs
+++ b/compiler/cx-backend-cranelift/src/value_type.rs
@@ -1,6 +1,4 @@
 use cranelift::codegen::ir;
-use cx_data_ast::parse::ast::CXTypeMap;
-use cx_data_ast::parse::value_type::{CXTypeKind, CXType};
 use cx_data_bytecode::types::{BCType, BCTypeKind};
 
 pub(crate) fn get_cranelift_abi_type(val_type: &BCType) -> ir::AbiParam {
@@ -17,7 +15,7 @@ pub(crate) fn get_cranelift_type(val_type: &BCType) -> ir::Type {
         
         BCTypeKind::Signed { bytes } |
         BCTypeKind::Unsigned { bytes }    => ir::Type::int(*bytes as u16 * 8)
-            .expect(format!("PANIC: Invalid integer size: {} bytes", *bytes).as_str()),
+            .unwrap_or_else(|| panic!("PANIC: Invalid integer size: {} bytes", *bytes)),
         
         BCTypeKind::Float { bytes: 2 }         => ir::types::F16,
         BCTypeKind::Float { bytes: 4 }         => ir::types::F32,
@@ -27,6 +25,6 @@ pub(crate) fn get_cranelift_type(val_type: &BCType) -> ir::Type {
         BCTypeKind::Struct { .. } |
         BCTypeKind::Pointer                    => ir::Type::int(64).unwrap(),
         
-        _ => panic!("PANIC: Unsupported type for Cranelift: {:?}", val_type),
+        _ => panic!("PANIC: Unsupported type for Cranelift: {val_type:?}"),
     }
 }

--- a/compiler/cx-backend-cranelift/src/value_type.rs
+++ b/compiler/cx-backend-cranelift/src/value_type.rs
@@ -13,6 +13,8 @@ pub(crate) fn get_cranelift_type(val_type: &BCType) -> ir::Type {
         BCTypeKind::Unsigned { bytes } if *bytes == 0 
             => ir::Type::int(8).expect("PANIC: Invalid integer size: 0 bytes"),
         
+        BCTypeKind::Bool                       => ir::types::I8,
+        
         BCTypeKind::Signed { bytes } |
         BCTypeKind::Unsigned { bytes }    => ir::Type::int(*bytes as u16 * 8)
             .expect(format!("PANIC: Invalid integer size: {} bytes", *bytes).as_str()),

--- a/compiler/cx-backend-llvm/src/arithmetic.rs
+++ b/compiler/cx-backend-llvm/src/arithmetic.rs
@@ -1,4 +1,4 @@
-use inkwell::values::{AnyValue, AnyValueEnum, IntMathValue, IntValue};
+use inkwell::values::{AnyValue, AnyValueEnum, IntValue};
 use cx_data_bytecode::{BCIntBinOp, BCPtrBinOp};
 use cx_data_bytecode::types::BCType;
 use crate::{CodegenValue, FunctionState, GlobalState};

--- a/compiler/cx-backend-llvm/src/instruction.rs
+++ b/compiler/cx-backend-llvm/src/instruction.rs
@@ -456,9 +456,9 @@ pub(crate) fn generate_instruction<'a>(
                 let signed = match block_instruction.value.type_.kind {
                     BCTypeKind::Signed { .. } => true,
                     BCTypeKind::Unsigned { .. } => false,
-                    BCTypeKind::Bool => false, 
-                    
-                    _ => log_error!("Unsupported type for IntegerBinOp"), 
+                    BCTypeKind::Bool => false,
+
+                    _ => log_error!("Unsupported type for IntegerBinOp"),
                 };
 
                 generate_int_binop(global_state, function_state, left, right, *op, signed)?
@@ -620,6 +620,7 @@ pub(crate) fn generate_instruction<'a>(
                 CodegenValue::NULL
             },
             
+            VirtualInstruction::BoolExtend { value } |
             VirtualInstruction::ZExtend { value } => {
                 let value = function_state
                     .get_val_ref(value)?

--- a/compiler/cx-backend-llvm/src/mangling.rs
+++ b/compiler/cx-backend-llvm/src/mangling.rs
@@ -1,5 +1,5 @@
 pub(crate) fn string_literal_name(
     str_id: usize
 ) -> String {
-    format!(".str_{}", str_id)
+    format!(".str_{str_id}")
 }

--- a/compiler/cx-backend-llvm/src/typing.rs
+++ b/compiler/cx-backend-llvm/src/typing.rs
@@ -71,7 +71,6 @@ pub(crate) fn bc_llvm_type<'a>(state: &GlobalState<'a>, _type: &BCType) -> Optio
             BCTypeKind::Signed { bytes, .. } |
             BCTypeKind::Unsigned { bytes, .. } => {
                 match *bytes {
-                    0 => state.context.bool_type().as_any_type_enum(),
                     1 => state.context.i8_type().as_any_type_enum(),
                     2 => state.context.i16_type().as_any_type_enum(),
                     4 => state.context.i32_type().as_any_type_enum(),
@@ -80,6 +79,7 @@ pub(crate) fn bc_llvm_type<'a>(state: &GlobalState<'a>, _type: &BCType) -> Optio
                     _ => panic!("Invalid integer size")
                 }
             },
+            BCTypeKind::Bool => state.context.bool_type().as_any_type_enum(),
             BCTypeKind::Float { bytes: 4 } => state.context.f32_type().as_any_type_enum(),
             BCTypeKind::Float { bytes: 8 } => state.context.f64_type().as_any_type_enum(),
 

--- a/compiler/cx-backend-llvm/src/typing.rs
+++ b/compiler/cx-backend-llvm/src/typing.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 use inkwell::AddressSpace;
 use crate::GlobalState;
 use inkwell::types::{AnyType, AnyTypeEnum, AsTypeRef, BasicMetadataTypeEnum, BasicTypeEnum, FunctionType};
-use inkwell::values::{AnyValueEnum, AsValueRef, BasicValueEnum};
+use inkwell::values::{AnyValueEnum, BasicValueEnum};
 use cx_data_bytecode::BCFunctionPrototype;
 use cx_data_bytecode::types::{BCType, BCTypeKind};
 
@@ -45,7 +45,7 @@ pub(crate) fn create_fn_proto<'a>(return_type: AnyTypeEnum<'a>, args: &[AnyTypeE
     let args = args
         .iter()
         .map(|arg| {
-            let basic_type = any_to_basic_type(arg.clone())?;
+            let basic_type = any_to_basic_type(*arg)?;
             
             unsafe { Some(BasicMetadataTypeEnum::new(basic_type.as_type_ref())) }
         })
@@ -59,7 +59,7 @@ pub(crate) fn create_fn_proto<'a>(return_type: AnyTypeEnum<'a>, args: &[AnyTypeE
             AnyTypeEnum::StructType(struct_type) => struct_type.fn_type(args.as_slice(), var_args),
             AnyTypeEnum::VoidType(void_type) => void_type.fn_type(args.as_slice(), var_args),
             
-            _ => panic!("Invalid return type, found: {:?}", return_type)
+            _ => panic!("Invalid return type, found: {return_type:?}")
         }
     )
 }
@@ -104,7 +104,7 @@ pub(crate) fn bc_llvm_type<'a>(state: &GlobalState<'a>, _type: &BCType) -> Optio
                     false
                 );
 
-                if name != "" {
+                if !name.is_empty() {
                     let anonymous_name = anonymous_struct_name();
                     let anonymous_struct_type = state.context.opaque_struct_type(&anonymous_name);
                     anonymous_struct_type.set_body(_types.as_slice(), false);
@@ -117,7 +117,7 @@ pub(crate) fn bc_llvm_type<'a>(state: &GlobalState<'a>, _type: &BCType) -> Optio
                     .unwrap_or_else(|| state.context.opaque_struct_type(name.as_str()))
                     .as_any_type_enum(),
 
-            _ => panic!("Invalid type: {:?}", _type)
+            _ => panic!("Invalid type: {_type:?}")
         }
     )
 }

--- a/compiler/cx-compiler-ast/src/lex/lexer.rs
+++ b/compiler/cx-compiler-ast/src/lex/lexer.rs
@@ -105,7 +105,7 @@ fn number_lex(iter: &mut CharIter) -> Option<Token> {
     while let Some(c) = iter.peek() {
         if c == '.' {
             dot = true;
-        } else if !c.is_digit(10) {
+        } else if !c.is_ascii_digit() {
             break;
         }
         iter.next();
@@ -114,7 +114,7 @@ fn number_lex(iter: &mut CharIter) -> Option<Token> {
     let kind = if dot {
         TokenKind::FloatLiteral(num.parse().unwrap())
     } else {
-        TokenKind::IntLiteral(num.parse().expect(&format!("Invalid number: {}\n", num)))
+        TokenKind::IntLiteral(num.parse().unwrap_or_else(|_| panic!("Invalid number: {num}\n")))
     };
     
     Some(
@@ -185,7 +185,7 @@ fn char_lex(iter: &mut CharIter) -> Option<Token> {
             assert_eq!(iter.next(), Some('\''));
             TokenKind::IntLiteral('\r' as i64)
         },
-        _ => panic!("Invalid character literal: '{}'", c)
+        _ => panic!("Invalid character literal: '{c}'")
     };
     
     Some(

--- a/compiler/cx-compiler-ast/src/lib.rs
+++ b/compiler/cx-compiler-ast/src/lib.rs
@@ -1,4 +1,4 @@
-use cx_data_ast::lex::token::{TokenKind, Token};
+use cx_data_ast::lex::token::Token;
 use cx_data_ast::parse::ast::CXAST;
 
 pub mod lex;

--- a/compiler/cx-compiler-ast/src/parse/global_scope.rs
+++ b/compiler/cx-compiler-ast/src/parse/global_scope.rs
@@ -2,10 +2,8 @@ use cx_data_ast::{assert_token_matches, try_next};
 use cx_data_ast::lex::token::{KeywordType, OperatorType, PunctuatorType, SpecifierType, TokenKind};
 use crate::parse::expression::{parse_expr, requires_semicolon};
 use cx_data_ast::parse::ast::{CXExpr, CXExprKind, CXFunctionPrototype, CXGlobalStmt, CXParameter, CXAST};
-use cx_data_ast::parse::identifier::CXIdent;
 use cx_data_ast::parse::parser::{ParserData, VisibilityMode};
-use cx_data_ast::parse::value_type::{CXTypeKind, CXType};
-use crate::parse::typing::{parse_initializer, parse_plain_typedef};
+use crate::parse::typing::parse_initializer;
 use cx_util::{log_error, point_log_error};
 use crate::parse::parsing_tools::goto_statement_end;
 
@@ -59,7 +57,7 @@ pub(crate) fn parse_import(data: &mut ParserData) -> Option<String> {
         match &tok.kind {
             TokenKind::Punctuator(PunctuatorType::Semicolon) => break,
             TokenKind::Operator(OperatorType::ScopeRes) => import_path.push('/'),
-            TokenKind::Identifier(ident) => import_path.push_str(&ident),
+            TokenKind::Identifier(ident) => import_path.push_str(ident),
 
             _ => {
                 log_error!("PARSER ERROR: Reached invalid token in import path: {:?}", tok);
@@ -137,7 +135,7 @@ pub(crate) fn parse_params(data: &mut ParserData) -> Option<ParseParamsResult> {
         }
 
         if let Some((name, type_)) = parse_initializer(data) {
-            let name = name.map(|name| name);
+            let name = name;
 
             params.push(CXParameter { name, type_ });
         } else {

--- a/compiler/cx-compiler-ast/src/parse/mod.rs
+++ b/compiler/cx-compiler-ast/src/parse/mod.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 pub use cx_compiler_modules::{serialize_function_data, serialize_module_data, serialize_type_data};
-use cx_data_ast::parse::ast::{CXGlobalStmt, CXTypeMap, CXAST};
-use cx_data_ast::parse::parser::{ParserData, VisibilityMode};
+use cx_data_ast::parse::ast::{CXTypeMap, CXAST};
+use cx_data_ast::parse::parser::ParserData;
 use cx_util::point_log_error;
 use global_scope::parse_global_stmt;
 use crate::parse::intrinsic_types::add_intrinsic_types;
@@ -14,7 +14,7 @@ pub mod operators;
 mod parsing_tools;
 pub mod intrinsic_types;
 
-pub fn parse_types_and_deps(mut data: ParserData, internal_dir: &str) -> Option<(CXTypeMap, Vec<String>, Vec<String>)> {
+pub fn parse_types_and_deps(mut data: ParserData) -> Option<(CXTypeMap, Vec<String>, Vec<String>)> {
     let (mut type_map, public_types, imports) = parse_types(&mut data)?;
 
     add_intrinsic_types(&mut type_map);

--- a/compiler/cx-compiler-ast/src/parse/operators.rs
+++ b/compiler/cx-compiler-ast/src/parse/operators.rs
@@ -169,9 +169,9 @@ pub(crate) fn parse_binop(data: &mut ParserData) -> Option<CXBinOp> {
                     return None;
                 }
             },
-            Some(TokenKind::Operator(op)) => op_to_binop(op.clone())?,
+            Some(TokenKind::Operator(op)) => op_to_binop(op)?,
             Some(TokenKind::Punctuator(punc)) => {
-                let punc = punc.clone();
+                let punc = punc;
                 data.toks.back();
                 match punc {
                     PunctuatorType::OpenBracket => CXBinOp::ArrayIndex,
@@ -182,7 +182,7 @@ pub(crate) fn parse_binop(data: &mut ParserData) -> Option<CXBinOp> {
             },
             Some(TokenKind::Assignment(op)) => {
                 let op = match op {
-                    Some(op) => Some(Box::new(op_to_binop(op.clone())?)),
+                    Some(op) => Some(Box::new(op_to_binop(op)?)),
                     None => None
                 };
 

--- a/compiler/cx-compiler-ast/src/parse/typing.rs
+++ b/compiler/cx-compiler-ast/src/parse/typing.rs
@@ -1,6 +1,6 @@
 use cx_data_ast::{assert_token_matches, next_kind, try_next};
 use cx_data_ast::lex::token::{KeywordType, OperatorType, PunctuatorType, SpecifierType, TokenKind};
-use cx_data_ast::parse::ast::{CXFunctionPrototype, CXTypeMap, CXAST};
+use cx_data_ast::parse::ast::{CXFunctionPrototype, CXTypeMap};
 use cx_data_ast::parse::identifier::{parse_intrinsic, parse_std_ident, CXIdent};
 use cx_data_ast::parse::parser::{ParserData, VisibilityMode};
 use cx_data_ast::parse::value_type::{CXTypeSpecifier, CXTypeKind, CXType, CX_CONST, CX_VOLATILE, PredeclarationType};
@@ -265,7 +265,7 @@ pub(crate) fn parse_typemods(data: &mut ParserData, acc_type: CXType) -> Option<
             let prototype = CXFunctionPrototype {
                 name: CXIdent::from("INTERNAL_FUNCTION_PTR_TYPE"),
                 return_type: acc_type,
-                params: params,
+                params,
                 var_args
             };
 
@@ -321,7 +321,7 @@ pub(crate) fn parse_type_base(data: &mut ParserData) -> Option<CXType> {
     let _type = match data.toks.peek()?.kind {
         TokenKind::Identifier(_) => Some(
             CXTypeKind::Identifier {
-                name: parse_std_ident(data)?.into(),
+                name: parse_std_ident(data)?,
                 predeclaration: PredeclarationType::None
             }.to_val_type()
         ),

--- a/compiler/cx-compiler-ast/src/preprocessor/preprocessor.rs
+++ b/compiler/cx-compiler-ast/src/preprocessor/preprocessor.rs
@@ -5,7 +5,7 @@ fn handle_non_directive(preprocessor: &mut Preprocessor, string: &str) -> String
     let mut result = string.to_string();
 
     for (token, value) in preprocessor.defined_tokens.iter() {
-        result = result.replace(format!("{}", token).as_str(), value);
+        result = result.replace(token.to_string().as_str(), value);
     }
 
     result
@@ -54,12 +54,12 @@ pub(crate) fn preprocess_line(preprocessor: &mut Preprocessor, mut string: &str)
             } else if file_name.starts_with("<") && file_name.ends_with(">") {
                 format!("{}/libc/", libary_path_prefix())
             } else {
-                panic!("Invalid include statement: {}", file_name);
+                panic!("Invalid include statement: {file_name}");
             };
 
             let path = format!("{}{}", prefix, &file_name[1.. file_name.len() - 1]);
             let string = std::fs::read_to_string(path.as_str())
-                .expect(format!("Failed to read file: {path}").as_str());
+                .unwrap_or_else(|_| panic!("Failed to read file: {path}"));
 
             string.lines()
                 .map(|line| preprocess_line(preprocessor, line))

--- a/compiler/cx-compiler-bytecode/src/aux_routines.rs
+++ b/compiler/cx-compiler-bytecode/src/aux_routines.rs
@@ -1,4 +1,3 @@
-use cx_data_ast::parse::ast::CXExpr;
 use cx_data_bytecode::types::{BCType, BCTypeKind};
 use cx_util::bytecode_error_log;
 use crate::builder::BytecodeBuilder;

--- a/compiler/cx-compiler-bytecode/src/builder.rs
+++ b/compiler/cx-compiler-bytecode/src/builder.rs
@@ -21,9 +21,6 @@ pub struct BytecodeBuilder {
     
     pub expr_type_map: ExprTypeMap,
 
-    pub current_block: u16,
-    pub current_instruction: u16,
-
     pub symbol_table: ScopedMap<ValueID>,
 
     function_context: Option<BytecodeFunctionContext>,
@@ -54,8 +51,6 @@ impl BytecodeBuilder {
             cx_function_map: fn_map,
 
             symbol_table: ScopedMap::new(),
-            current_block: 0,
-            current_instruction: 0,
 
             function_context: None
         }
@@ -215,6 +210,10 @@ impl BytecodeBuilder {
     pub fn create_global_string(&mut self, string: String) -> u32 {
         self.global_strings.push(string.clone());
         self.global_strings.len() as u32 - 1
+    }
+    
+    pub fn current_block(&self) -> ElementID {
+        self.fun().current_block
     }
 
     pub fn create_block(&mut self) -> ElementID {

--- a/compiler/cx-compiler-bytecode/src/builder.rs
+++ b/compiler/cx-compiler-bytecode/src/builder.rs
@@ -153,7 +153,7 @@ impl BytecodeBuilder {
             BCTypeKind::Bool =>
                 self.bool_const(value != 0),
             
-            _ => panic!("INTERNAL PANIC: Attempted to create integer constant with non-integer type: {:?}", bc_type)
+            _ => panic!("INTERNAL PANIC: Attempted to create integer constant with non-integer type: {bc_type:?}")
         }
     }
     
@@ -205,7 +205,7 @@ impl BytecodeBuilder {
     
     pub fn get_type(&self, value_id: ValueID) -> Option<&BCType> {
         let Some(value) = self.get_variable(value_id) else {
-            panic!("INTERNAL PANIC: Failed to get variable for value id: {:?}", value_id);
+            panic!("INTERNAL PANIC: Failed to get variable for value id: {value_id:?}");
         };
         
         Some(&value.type_)
@@ -215,7 +215,7 @@ impl BytecodeBuilder {
         let cond_block = self.create_block();
 
         let context = self.fun_mut();
-        context.continue_stack.push(cond_block.clone());
+        context.continue_stack.push(cond_block);
 
         cond_block
     }
@@ -224,7 +224,7 @@ impl BytecodeBuilder {
         let merge_block = self.create_named_block("merge");
 
         let context = self.fun_mut();
-        context.merge_stack.push(merge_block.clone());
+        context.merge_stack.push(merge_block);
 
         merge_block
     }

--- a/compiler/cx-compiler-bytecode/src/cx_maps.rs
+++ b/compiler/cx-compiler-bytecode/src/cx_maps.rs
@@ -252,6 +252,9 @@ pub(crate) fn convert_fixed_type_kind(cx_type_map: &CXTypeMap, cx_type_kind: &CX
 
             CXTypeKind::Opaque { size, .. } =>
                 BCTypeKind::Opaque { bytes: *size },
+            
+            CXTypeKind::Bool => 
+                BCTypeKind::Bool,
 
             CXTypeKind::Integer { signed: true, bytes} =>
                 BCTypeKind::Signed { bytes: *bytes },

--- a/compiler/cx-compiler-bytecode/src/cx_maps.rs
+++ b/compiler/cx-compiler-bytecode/src/cx_maps.rs
@@ -24,7 +24,7 @@ impl BytecodeBuilder {
     ) -> Option<BCFunctionPrototype> {
         let Some(CXTypeKind::Function { prototype })
             = cx_type.intrinsic_type(&self.cx_type_map) else {
-            panic!("Expected function type, got: {:?}", cx_type);
+            panic!("Expected function type, got: {cx_type:?}");
         };
         
         self.convert_cx_prototype(prototype)
@@ -104,7 +104,7 @@ impl BytecodeBuilder {
                 CXBinOp::Assign(_) |
                 CXBinOp::Access |
                 CXBinOp::MethodCall |
-                CXBinOp::ArrayIndex => panic!("Invalid binary operation: {:?}", op),
+                CXBinOp::ArrayIndex => panic!("Invalid binary operation: {op:?}"),
             }
         )
     }
@@ -289,7 +289,7 @@ pub(crate) fn convert_fixed_type_kind(cx_type_map: &CXTypeMap, cx_type_kind: &CX
                         None => "".to_string()
                     },
                     fields: fields.iter()
-                        .map(|(_name, _type)| Some((_name.clone(), convert_fixed_type(cx_type_map, &_type)?)))
+                        .map(|(_name, _type)| Some((_name.clone(), convert_fixed_type(cx_type_map, _type)?)))
                         .collect::<Option<Vec<_>>>()?
                 },
             CXTypeKind::Union { fields, name } =>
@@ -299,7 +299,7 @@ pub(crate) fn convert_fixed_type_kind(cx_type_map: &CXTypeMap, cx_type_kind: &CX
                         None => "".to_string()
                     },
                     fields: fields.iter()
-                        .map(|(_name, _type)| Some((_name.clone(), convert_fixed_type(cx_type_map, &_type)?)))
+                        .map(|(_name, _type)| Some((_name.clone(), convert_fixed_type(cx_type_map, _type)?)))
                         .collect::<Option<Vec<_>>>()?
                 },
 

--- a/compiler/cx-compiler-bytecode/src/implicit_cast.rs
+++ b/compiler/cx-compiler-bytecode/src/implicit_cast.rs
@@ -123,6 +123,7 @@ pub(crate) fn implicit_cast(
         CXCastType::IntegralCast => {
             let (_type, signed) = match get_intrinsic_type(&builder.cx_type_map, to_type)? {
                 CXTypeKind::Integer { signed, .. } => (to_type.clone(), *signed),
+                CXTypeKind::Bool => (CXTypeKind::Integer { bytes: 1, signed: false }.to_val_type(), false),
 
                 _ => panic!("INTERNAL PANIC: Invalid integral cast type")
             };

--- a/compiler/cx-compiler-modules/src/lib.rs
+++ b/compiler/cx-compiler-modules/src/lib.rs
@@ -14,7 +14,7 @@ pub fn serialize_type_data<'a>(internal_path: &str, type_map: &CXTypeMap, types:
     
     std::fs::create_dir_all(format!("{}/{}", directory.parent()?.display(), directory.file_stem()?.display()))
         .expect("Failed to create internal directory");
-    let type_file_dir = format!("{}/.cx-types", internal_path);
+    let type_file_dir = format!("{internal_path}/.cx-types");
     let mut type_file = File::create(type_file_dir)
         .expect("Failed to create type file");
     
@@ -37,7 +37,7 @@ pub fn serialize_function_data<'a>(internal_path: &str, function_map: &CXFunctio
     std::fs::create_dir_all(directory.parent()?)
         .expect("Failed to create internal directory");
     
-    let mut function_file = File::create(format!("{}/.cx-functions", internal_path))
+    let mut function_file = File::create(format!("{internal_path}/.cx-functions"))
         .expect("Failed to create function file");
     
     for fn_name in functions {
@@ -58,9 +58,9 @@ pub fn serialize_function_data<'a>(internal_path: &str, function_map: &CXFunctio
 pub fn deserialize_type_data(file_path: &str) -> Option<Vec<(String, CXType)>> {
     let mut types = Vec::new();
     
-    let type_file_path = format!(".internal/{}/.cx-types", file_path);
+    let type_file_path = format!(".internal/{file_path}/.cx-types");
     let type_file = File::open(&type_file_path)
-        .expect(format!("Failed to open type file: {}", type_file_path).as_str());
+        .unwrap_or_else(|_| panic!("Failed to open type file: {type_file_path}"));
     
     for line in BufReader::new(type_file).lines() {
         let line = line.expect("Failed to read line from type file");
@@ -76,7 +76,7 @@ pub fn deserialize_type_data(file_path: &str) -> Option<Vec<(String, CXType)>> {
 pub fn deserialize_function_data(file_path: &str) -> Option<Vec<CXFunctionPrototype>> {
     let mut functions = Vec::new();
     
-    let function_file_path = format!(".internal/{}/.cx-functions", file_path);
+    let function_file_path = format!(".internal/{file_path}/.cx-functions");
     let function_file = File::open(&function_file_path)
         .expect("Failed to open function file");
     
@@ -111,7 +111,7 @@ pub fn serialize_module_data(ast: &CXAST) -> Option<()> {
     let mut function_file = File::create(format!("{}/.cx-functions", ast.internal_path))
         .expect("Failed to create function file");
     
-    for (_, function) in &ast.function_map {
+    for function in ast.function_map.values() {
         let serialized = serde_json::to_string(function)
             .expect("Failed to serialize function");
         
@@ -129,11 +129,11 @@ pub fn deserialize_module_data(file_path: &str) -> Option<ModuleData> {
         functions: Vec::new(),
     };
     
-    let type_file_path = format!(".internal/{}/.cx-types", file_path);
-    let function_file_path = format!(".internal/{}/.cx-functions", file_path);
+    let type_file_path = format!(".internal/{file_path}/.cx-types");
+    let function_file_path = format!(".internal/{file_path}/.cx-functions");
     
     let type_file = File::open(&type_file_path)
-        .expect(format!("Failed to open type file: {}", type_file_path).as_str());
+        .unwrap_or_else(|_| panic!("Failed to open type file: {type_file_path}"));
     
     for line in BufReader::new(type_file).lines() {
         let line = line.expect("Failed to read line from type file");
@@ -144,7 +144,7 @@ pub fn deserialize_module_data(file_path: &str) -> Option<ModuleData> {
     }
     
     let function_file = File::open(&function_file_path)
-        .expect(format!("Failed to open function file: {}", function_file_path).as_str());
+        .unwrap_or_else(|_| panic!("Failed to open function file: {function_file_path}"));
     
     for line in BufReader::new(function_file).lines() {
         let line = line.expect("Failed to read line from function file");

--- a/compiler/cx-compiler-typechecker/src/casting.rs
+++ b/compiler/cx-compiler-typechecker/src/casting.rs
@@ -1,5 +1,3 @@
-use std::clone;
-use std::ops::Deref;
 use crate::TypeEnvironment;
 use cx_data_ast::parse::ast::{CXBinOp, CXCastType, CXExpr, CXExprKind};
 use cx_data_ast::parse::value_type::{same_type, CXTypeKind, CXType};
@@ -188,7 +186,7 @@ pub(crate) fn ptr_int_binop_coercion(env: &mut TypeEnvironment, op: CXBinOp,
         _ => panic!("Invalid binary operation {op} for pointer type")
     };
     
-    binop_type(&op, Some(&pointer_inner), &pointer_inner.clone().pointer_to())
+    binop_type(&op, Some(pointer_inner), &pointer_inner.clone().pointer_to())
 }
 
 pub(crate) fn ptr_ptr_binop_coercion(env: &mut TypeEnvironment, op: CXBinOp,
@@ -207,7 +205,7 @@ pub(crate) fn ptr_ptr_binop_coercion(env: &mut TypeEnvironment, op: CXBinOp,
         _ => panic!("Invalid binary operation {op} for pointer type")
     };
     
-    binop_type(&op, Some(&pointer_inner), &pointer_inner.clone())
+    binop_type(&op, Some(pointer_inner), &pointer_inner.clone())
 }
 
 pub(crate) fn binop_type(op: &CXBinOp, pointer_inner: Option<&CXType>, lhs: &CXType) -> Option<CXType> {

--- a/compiler/cx-compiler-typechecker/src/checker.rs
+++ b/compiler/cx-compiler-typechecker/src/checker.rs
@@ -179,6 +179,11 @@ fn type_check_inner(env: &mut TypeEnvironment, expr: &mut CXExpr) -> Option<CXTy
                             implicit_cast(env, args[i], &va_type, &to_type)?;
                         }
                     },
+                    
+                    CXTypeKind::Bool { .. } => {
+                        let to_type = CXTypeKind::Integer { bytes: 8, signed: false }.to_val_type();
+                        implicit_cast(env, args[i], &va_type, &to_type)?;
+                    },
 
                     _ => log_error!("TYPE ERROR: Cannot coerce value {} for varargs, expected intrinsic type or pointer!", args[i]),
                 }

--- a/compiler/cx-compiler-typechecker/src/checker.rs
+++ b/compiler/cx-compiler-typechecker/src/checker.rs
@@ -4,7 +4,7 @@ use cx_data_ast::parse::value_type::{get_intrinsic_type, same_type, CXTypeKind, 
 use cx_util::{expr_error_log, log_error};
 use crate::struct_typechecking::typecheck_access;
 use crate::casting::{alg_bin_op_coercion, explicit_cast, implicit_cast};
-use crate::{type_check, TypeEnvironment};
+use crate::TypeEnvironment;
 
 pub(crate) fn type_check_traverse<'a>(env: &'a mut TypeEnvironment, expr: &mut CXExpr) -> Option<&'a CXType> {
     let _type = type_check_inner(env, expr)?;
@@ -59,7 +59,7 @@ fn type_check_inner(env: &mut TypeEnvironment, expr: &mut CXExpr) -> Option<CXTy
                 CXUnOp::AddressOf => {
                     let operand_type = type_check_traverse(env, operand.as_mut())?.clone();
 
-                    match operand_type.intrinsic_type(&env.type_map)? {
+                    match operand_type.intrinsic_type(env.type_map)? {
                         CXTypeKind::MemoryAlias(inner) => Some(inner.clone().pointer_to()),
                         CXTypeKind::Function { .. } => coerce_value(env, operand.as_mut()),
 
@@ -88,7 +88,7 @@ fn type_check_inner(env: &mut TypeEnvironment, expr: &mut CXExpr) -> Option<CXTy
                         log_error!("TYPE ERROR: Increment operator can only be applied to memory references, found: {operand}");
                     };
                     
-                    match get_intrinsic_type(env.type_map, &inner).cloned()? {
+                    match get_intrinsic_type(env.type_map, inner).cloned()? {
                         CXTypeKind::Integer { .. } |
                         CXTypeKind::PointerTo(_) => {},
 
@@ -136,11 +136,11 @@ fn type_check_inner(env: &mut TypeEnvironment, expr: &mut CXExpr) -> Option<CXTy
         CXExprKind::BinOp { lhs, rhs, op: CXBinOp::MethodCall } => {
             let mut lhs_type = coerce_mem_ref(env, lhs)?;
 
-            if let Some(CXTypeKind::PointerTo(inner)) = lhs_type.intrinsic_type(&env.type_map) {
+            if let Some(CXTypeKind::PointerTo(inner)) = lhs_type.intrinsic_type(env.type_map) {
                 lhs_type = *inner.clone();
             }
 
-            let CXTypeKind::Function { prototype } = lhs_type.intrinsic_type(&env.type_map).cloned()? else {
+            let CXTypeKind::Function { prototype } = lhs_type.intrinsic_type(env.type_map).cloned()? else {
                 log_error!("TYPE ERROR: Method call operator can only be applied to functions, found: {lhs} of type {lhs_type}");
             };
 
@@ -180,7 +180,7 @@ fn type_check_inner(env: &mut TypeEnvironment, expr: &mut CXExpr) -> Option<CXTy
                         }
                     },
                     
-                    CXTypeKind::Bool { .. } => {
+                    CXTypeKind::Bool => {
                         let to_type = CXTypeKind::Integer { bytes: 8, signed: false }.to_val_type();
                         implicit_cast(env, args[i], &va_type, &to_type)?;
                     },
@@ -310,7 +310,7 @@ fn type_check_inner(env: &mut TypeEnvironment, expr: &mut CXExpr) -> Option<CXTy
                 if !value_type.is_structure_ref(env.type_map) {
                     implicit_coerce(env, value, env.return_type.clone())?;
                 }
-            } else if !env.return_type.is_void(&env.type_map) {
+            } else if !env.return_type.is_void(env.type_map) {
                 log_error!("TYPE ERROR: Function with empty return in non-void context");
             }
 

--- a/compiler/cx-compiler-typechecker/src/importing.rs
+++ b/compiler/cx-compiler-typechecker/src/importing.rs
@@ -13,12 +13,12 @@ pub(crate) fn import_module_data(cxast: &mut CXAST) {
         let cx_path = Path::new(&cx_path_str);
         
         if !internal_type_path.exists() {
-            eprintln!("Import path does not exist: {}", type_path_str);
+            eprintln!("Import path does not exist: {type_path_str}");
             exit(1);
         }
         
         if !cx_path.exists() {
-            eprintln!("Source file does not exist: {}", cx_path_str);
+            eprintln!("Source file does not exist: {cx_path_str}");
             exit(1);
         }
         

--- a/compiler/cx-compiler-typechecker/src/lib.rs
+++ b/compiler/cx-compiler-typechecker/src/lib.rs
@@ -1,4 +1,4 @@
-use cx_data_ast::lex::token::{TokenKind, Token};
+use cx_data_ast::lex::token::Token;
 use cx_data_ast::parse::ast::{CXFunctionMap, CXGlobalStmt, CXParameter, CXTypeMap, CXAST};
 use cx_data_ast::parse::value_type::CXType;
 use cx_data_bytecode::node_type_map::ExprTypeMap;

--- a/compiler/cx-compiler-typechecker/src/struct_typechecking.rs
+++ b/compiler/cx-compiler-typechecker/src/struct_typechecking.rs
@@ -1,5 +1,5 @@
 use cx_data_ast::parse::ast::{CXExpr, CXExprKind, CXUnOp};
-use cx_data_ast::parse::value_type::{struct_field_type, CXTypeKind, CXType};
+use cx_data_ast::parse::value_type::{CXTypeKind, CXType};
 use cx_util::{log_error};
 use crate::checker::{coerce_value, type_check_traverse};
 use crate::TypeEnvironment;

--- a/compiler/cx-data-ast/src/lex/format.rs
+++ b/compiler/cx-data-ast/src/lex/format.rs
@@ -10,10 +10,10 @@ impl Display for Token {
 impl Display for TokenKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            TokenKind::Identifier(name) => write!(f, "{}", name),
-            TokenKind::Intrinsic(intrin) => write!(f, "{}", intrin),
+            TokenKind::Identifier(name) => write!(f, "{name}"),
+            TokenKind::Intrinsic(intrin) => write!(f, "{intrin}"),
 
-            _ => write!(f, "{:?}", self),
+            _ => write!(f, "{self:?}"),
         }
     }
 }
@@ -27,7 +27,7 @@ impl Display for IntrinsicType {
             IntrinsicType::Void => write!(f, "void"),
             IntrinsicType::Bool => write!(f, "bool"),
 
-            _ => write!(f, "{:?}", self),
+            _ => write!(f, "{self:?}"),
         }
     }
 }

--- a/compiler/cx-data-ast/src/parse/ast.rs
+++ b/compiler/cx-data-ast/src/parse/ast.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use uuid::Uuid;
 use serde::{Deserialize, Serialize};
-use crate::lex::token::{TokenKind, Token};
+use crate::lex::token::Token;
 use crate::parse::value_type::{CXType};
 use crate::parse::identifier::CXIdent;
 

--- a/compiler/cx-data-ast/src/parse/format.rs
+++ b/compiler/cx-data-ast/src/parse/format.rs
@@ -223,6 +223,7 @@ impl Display for CXTypeKind {
                 let float_bytes = *bytes * 8;
                 write!(f, "f{}", float_bytes)
             },
+            CXTypeKind::Bool => write!(f, "bool"),
             CXTypeKind::Structured { fields, name } => {
                 let field_strs = fields.iter()
                     .map(|(name, type_)| format!("{}: {}", name, type_))

--- a/compiler/cx-data-ast/src/parse/format.rs
+++ b/compiler/cx-data-ast/src/parse/format.rs
@@ -1,4 +1,3 @@
-use std::env::args;
 use crate::parse::ast::{CXBinOp, CXExpr, CXExprKind, CXFunctionPrototype, CXGlobalStmt, CXInitIndex, CXParameter, CXUnOp, CXAST};
 use crate::parse::value_type::{CXTypeKind, CXType};
 use cx_util::format::{dedent, indent};
@@ -8,7 +7,7 @@ use std::fmt::{Display, Formatter};
 impl Display for CXAST {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         for stmt in &self.global_stmts {
-            writeln!(f, "{}\n", stmt)?;
+            writeln!(f, "{stmt}\n")?;
         }
 
         Ok(())
@@ -38,7 +37,7 @@ impl Display for CXFunctionPrototype {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "fn {}({}) -> {}",
                self.name,
-               self.params.iter().map(|p| format!("{}", p)).collect::<Vec<_>>().join(", "),
+               self.params.iter().map(|p| format!("{p}")).collect::<Vec<_>>().join(", "),
                self.return_type
         )
     }
@@ -169,8 +168,7 @@ impl Display for CXExprKind {
                     fwriteln!(f, "}} else {{")?;
                     fwriteln!(f, "{}", else_branch)?;
                     dedent();
-                } else {
-                }
+                } 
                 fwrite!(f, "}}")
             },
 
@@ -217,60 +215,60 @@ impl Display for CXTypeKind {
             CXTypeKind::Integer { bytes, signed } => {
                 let signed_str = if *signed { "i" } else { "u" };
                 let signed_bytes = *bytes * 8;
-                write!(f, "{}{}", signed_str, signed_bytes)
+                write!(f, "{signed_str}{signed_bytes}")
             },
             CXTypeKind::Float { bytes } => {
                 let float_bytes = *bytes * 8;
-                write!(f, "f{}", float_bytes)
+                write!(f, "f{float_bytes}")
             },
             CXTypeKind::Bool => write!(f, "bool"),
             CXTypeKind::Structured { fields, name } => {
                 let field_strs = fields.iter()
-                    .map(|(name, type_)| format!("{}: {}", name, type_))
+                    .map(|(name, type_)| format!("{name}: {type_}"))
                     .collect::<Vec<_>>()
                     .join(", ");
                 let name_str = if let Some(name) = name {
-                    format!("{} ", name)
+                    format!("{name} ")
                 } else {
                     "".to_string()
                 };
 
-                write!(f, "struct {} {{ {} }}", name_str, field_strs)
+                write!(f, "struct {name_str} {{ {field_strs} }}")
             },
             CXTypeKind::Union { fields, name } => {
                 let field_strs = fields.iter()
-                    .map(|(name, type_)| format!("{}: {}", name, type_))
+                    .map(|(name, type_)| format!("{name}: {type_}"))
                     .collect::<Vec<_>>()
                     .join(", ");
                 let name_str = if let Some(name) = name {
-                    format!("{} ", name)
+                    format!("{name} ")
                 } else {
                     "".to_string()
                 };
 
-                write!(f, "union {} {{ {} }}", name_str, field_strs)
+                write!(f, "union {name_str} {{ {field_strs} }}")
             },
             CXTypeKind::Unit => write!(f, "()"),
             CXTypeKind::PointerTo(inner) => {
-                write!(f, "*{}", inner)
+                write!(f, "*{inner}")
             },
             CXTypeKind::Array { size, _type } => {
-                write!(f, "[{}; {}]", size, _type)
+                write!(f, "[{size}; {_type}]")
             },
             CXTypeKind::VariableLengthArray { _type, .. } => {
-                write!(f, "[{}; variable]", _type)
+                write!(f, "[{_type}; variable]")
             },
             CXTypeKind::Opaque { name, size } => {
-                write!(f, "OPAQUE_{}(\"{}\")", size, name)
+                write!(f, "OPAQUE_{size}(\"{name}\")")
             },
             CXTypeKind::Identifier { name, .. } => {
-                write!(f, "{}", name)
+                write!(f, "{name}")
             },
             CXTypeKind::Function { prototype } => {
-                write!(f, "fn {}", prototype)
+                write!(f, "fn {prototype}")
             },
             CXTypeKind::MemoryAlias(inner) => {
-                write!(f, "mem({})", inner)
+                write!(f, "mem({inner})")
             },
         }
     }

--- a/compiler/cx-data-ast/src/parse/identifier.rs
+++ b/compiler/cx-data-ast/src/parse/identifier.rs
@@ -100,7 +100,7 @@ pub fn parse_intrinsic(data: &mut ParserData) -> Option<CXIdent> {
     let mut ss = String::new();
 
     while let Some(TokenKind::Intrinsic(ident)) = data.toks.peek().map(|tok| &tok.kind) {
-        ss.push_str(format!("{:?}", ident).to_lowercase().as_str());
+        ss.push_str(format!("{ident:?}").to_lowercase().as_str());
         data.toks.next();
     }
 

--- a/compiler/cx-data-ast/src/parse/macros.rs
+++ b/compiler/cx-data-ast/src/parse/macros.rs
@@ -4,7 +4,7 @@ pub fn token_string(toks: &TokenIter, start_index: usize, end_index: usize) -> S
     let mut tokens = String::new();
     
     for tok in &toks.slice[start_index..end_index] {
-        tokens.push_str(&format!("{} ", tok));
+        tokens.push_str(&format!("{tok} "));
     }
 
     tokens.push('\n');
@@ -19,19 +19,19 @@ pub fn error_pointer(toks: &TokenIter) -> String {
     let mut error_tokens = String::new();
 
     for tok in &toks.slice[toks.index - previous_tokens.. toks.index] {
-        error_tokens.push_str(&format!("{} ", tok));
+        error_tokens.push_str(&format!("{tok} "));
     }
 
     let mut error_pointer = String::new();
 
     for _ in 0..error_tokens.len() {
-        error_pointer.push_str(" ");
+        error_pointer.push(' ');
     }
 
     error_pointer.push_str("^ ");
 
     for tok in &toks.slice[toks.index..toks.index + next_tokens] {
-        error_tokens.push_str(&format!("{} ", tok));
+        error_tokens.push_str(&format!("{tok} "));
     }
 
     error_tokens.push('\n');

--- a/compiler/cx-data-ast/src/parse/parser.rs
+++ b/compiler/cx-data-ast/src/parse/parser.rs
@@ -1,4 +1,4 @@
-use crate::lex::token::{TokenKind, Token};
+use crate::lex::token::Token;
 use crate::parse::value_type::{CXType};
 use cx_util::scoped_map::ScopedMap;
 use std::collections::HashSet;

--- a/compiler/cx-data-ast/src/parse/value_type.rs
+++ b/compiler/cx-data-ast/src/parse/value_type.rs
@@ -21,6 +21,7 @@ pub struct CXType {
 pub enum CXTypeKind {
     Integer { bytes: u8, signed: bool },
     Float { bytes: u8 },
+    Bool,
     Structured {
         name: Option<CXIdent>,
         fields: Vec<(String, CXType)>
@@ -222,6 +223,7 @@ pub fn same_type(type_map: &CXTypeMap, t1: &CXType, t2: &CXType) -> bool {
             CXTypeKind::Float { bytes: t2_bytes }) =>
             t1_bytes == t2_bytes,
 
+        (CXTypeKind::Bool, CXTypeKind::Bool) |
         (CXTypeKind::Unit, CXTypeKind::Unit) =>
             true,
 

--- a/compiler/cx-data-ast/src/parse/value_type.rs
+++ b/compiler/cx-data-ast/src/parse/value_type.rs
@@ -1,6 +1,6 @@
 use cx_util::log_error;
 use serde::{Deserialize, Serialize};
-use crate::parse::ast::{CXBinOp, CXExpr, CXExprKind, CXFunctionPrototype, CXTypeMap};
+use crate::parse::ast::{CXExpr, CXFunctionPrototype, CXTypeMap};
 use crate::parse::identifier::CXIdent;
 
 pub type CXTypeSpecifier = u8;
@@ -189,10 +189,10 @@ pub fn same_type(type_map: &CXTypeMap, t1: &CXType, t2: &CXType) -> bool {
             true,
 
         (CXTypeKind::Identifier { name: name1, .. }, _) =>
-            same_type(type_map, &type_map.get(name1.as_str()).unwrap(), t2),
+            same_type(type_map, type_map.get(name1.as_str()).unwrap(), t2),
 
         (_, CXTypeKind::Identifier { name: name2, .. }) =>
-            same_type(type_map, t1, &type_map.get(name2.as_str()).expect(format!("Type not found: {name2}").as_str())),
+            same_type(type_map, t1, type_map.get(name2.as_str()).unwrap_or_else(|| panic!("Type not found: {name2}"))),
 
         (CXTypeKind::Array { _type: t1_type, .. },
          CXTypeKind::Array { _type: t2_type, .. }) =>

--- a/compiler/cx-data-bytecode/src/format.rs
+++ b/compiler/cx-data-bytecode/src/format.rs
@@ -19,12 +19,12 @@ impl Display for BytecodeFunction {
         writeln!(f, "{}:", self.prototype)?;
 
         for (i, block) in self.blocks.iter().enumerate() {
-            write!(f, "block{}", i)?;
-            if block.debug_name != "" {
+            write!(f, "block{i}")?;
+            if !block.debug_name.is_empty() {
                 write!(f, "  // {}", block.debug_name)?;
             }
             writeln!(f, ":")?;
-            writeln!(f, "{}", block)?;
+            writeln!(f, "{block}")?;
         }
 
         Ok(())
@@ -34,7 +34,7 @@ impl Display for BytecodeFunction {
 impl Display for FunctionBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         for (i, instruction) in self.body.iter().enumerate() {
-            writeln!(f, "    v{i} = {}", instruction)?;
+            writeln!(f, "    v{i} = {instruction}")?;
         }
 
         Ok(())
@@ -78,10 +78,10 @@ impl Display for VirtualInstruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             VirtualInstruction::Allocate { size, alignment } => {
-                write!(f, "alloca {size} (alignment: {})", alignment)
+                write!(f, "alloca {size} (alignment: {alignment})")
             },
             VirtualInstruction::VariableAllocate { size, alignment } => {
-                write!(f, "variable_alloca {size} (alignment: {})", size)
+                write!(f, "variable_alloca {size} (alignment: {alignment})")
             },
             VirtualInstruction::FunctionParameter { param_index } => {
                 write!(f, "parameter {param_index}")
@@ -93,13 +93,13 @@ impl Display for VirtualInstruction {
                 write!(f, "store {type_} {value} -> {memory}")
             },
             VirtualInstruction::Immediate { value } => {
-                write!(f, "immediate {}", value)
+                write!(f, "immediate {value}")
             },
             VirtualInstruction::FloatImmediate { value } => {
-                write!(f, "float_immediate {}", value)
+                write!(f, "float_immediate {value}")
             },
             VirtualInstruction::StructAccess { struct_, struct_type, field_index, field_offset, .. } => {
-                write!(f, "struct_access {} ({})[index: {}; offset: {}]", struct_, struct_type, field_index, field_offset)
+                write!(f, "struct_access {struct_} ({struct_type})[index: {field_index}; offset: {field_offset}]")
             },
             VirtualInstruction::BoolExtend { value } => {
                 write!(f, "bool_extend {value}")
@@ -333,30 +333,30 @@ impl Display for BCTypeKind {
             BCTypeKind::Pointer => write!(f, "*"),
 
             BCTypeKind::Array { element, size } => {
-                write!(f, "[{}; {}]", element, size)
+                write!(f, "[{element}; {size}]")
             },
             BCTypeKind::Struct { fields, .. } => {
                 let fields = fields
                     .iter()
-                    .map(|(name, _type)| format!("{}: {}", name, _type))
+                    .map(|(name, _type)| format!("{name}: {_type}"))
                     .collect::<Vec<_>>()
                     .join(", ");
 
-                write!(f, "struct {{ {} }}", fields)
+                write!(f, "struct {{ {fields} }}")
             },
             BCTypeKind::Union { fields, .. } => {
                 let fields = fields
                     .iter()
-                    .map(|(name, _type)| format!("{}: {}", name, _type))
+                    .map(|(name, _type)| format!("{name}: {_type}"))
                     .collect::<Vec<_>>()
                     .join(", ");
 
-                write!(f, "union {{ {} }}", fields)
+                write!(f, "union {{ {fields} }}")
             },
 
             BCTypeKind::Unit => write!(f, "()"),
             BCTypeKind::VariableSized { size, alignment } => {
-                write!(f, "variable_sized (size: {}, alignment: {})", size, alignment)
+                write!(f, "variable_sized (size: {size}, alignment: {alignment})")
             },
         }
     }

--- a/compiler/cx-data-bytecode/src/format.rs
+++ b/compiler/cx-data-bytecode/src/format.rs
@@ -101,6 +101,9 @@ impl Display for VirtualInstruction {
             VirtualInstruction::StructAccess { struct_, struct_type, field_index, field_offset, .. } => {
                 write!(f, "struct_access {} ({})[index: {}; offset: {}]", struct_, struct_type, field_index, field_offset)
             },
+            VirtualInstruction::BoolExtend { value } => {
+                write!(f, "bool_extend {value}")
+            },
             VirtualInstruction::ZExtend { value } => {
                 write!(f, "zextend {value}")
             },

--- a/compiler/cx-data-bytecode/src/format.rs
+++ b/compiler/cx-data-bytecode/src/format.rs
@@ -325,6 +325,7 @@ impl Display for BCTypeKind {
             BCTypeKind::Opaque { bytes } => write!(f, "opaque_{}", *bytes),
             BCTypeKind::Signed { bytes } => write!(f, "i{}", bytes * 8),
             BCTypeKind::Unsigned { bytes } => write!(f, "u{}", bytes * 8),
+            BCTypeKind::Bool => write!(f, "bool"),
             BCTypeKind::Float { bytes } => write!(f, "f{}", bytes * 8),
             BCTypeKind::Pointer => write!(f, "*"),
 

--- a/compiler/cx-data-bytecode/src/format.rs
+++ b/compiler/cx-data-bytecode/src/format.rs
@@ -128,6 +128,20 @@ impl Display for VirtualInstruction {
             VirtualInstruction::Branch { condition, true_block, false_block } => {
                 write!(f, "branch on {condition}; true -> block{true_block}, false -> block{false_block}")
             },
+            VirtualInstruction::Phi { predecessors: from } => {
+                write!(f, "phi")?;
+                if !from.is_empty() {
+                    write!(f, " from [")?;
+                    for (i, (value, block_id)) in from.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{value} @ b{block_id}")?;
+                    }
+                    write!(f, "]")?;
+                }
+                Ok(())
+            },
             VirtualInstruction::Jump { target } => {
                 write!(f, "jump {target}")
             },

--- a/compiler/cx-data-bytecode/src/lib.rs
+++ b/compiler/cx-data-bytecode/src/lib.rs
@@ -117,6 +117,10 @@ pub enum VirtualInstruction {
     SExtend {
         value: ValueID,
     },
+    
+    Phi {
+        predecessors: Vec<(ValueID, ElementID)>,
+    },
 
     Trunc {
         value: ValueID

--- a/compiler/cx-data-bytecode/src/lib.rs
+++ b/compiler/cx-data-bytecode/src/lib.rs
@@ -110,6 +110,13 @@ pub enum VirtualInstruction {
         type_: BCType
     },
 
+    // Since a bool in Cranelift is represented as an i8, extending from an i8 to an i8
+    // should be a no-op, but using a plain ZExtend attempts to convert it, thus causing
+    // an error,
+    BoolExtend {
+        value: ValueID,
+    },
+    
     ZExtend {
         value: ValueID,
     },

--- a/compiler/cx-data-bytecode/src/node_type_map.rs
+++ b/compiler/cx-data-bytecode/src/node_type_map.rs
@@ -7,6 +7,12 @@ pub struct ExprTypeMap {
     inner: HashMap<u64, CXType>
 }
 
+impl Default for ExprTypeMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ExprTypeMap {
     fn node_hash(&self, expr: &CXExpr) -> u64 {
         // Using the address can't possibly go wrong, right?

--- a/compiler/cx-data-bytecode/src/types.rs
+++ b/compiler/cx-data-bytecode/src/types.rs
@@ -33,7 +33,7 @@ impl BCTypeSize {
     pub fn assert_fixed(self, msg: &str) -> usize {
         match self {
             BCTypeSize::Fixed(size) => size,
-            BCTypeSize::Variable(_) => panic!("{}: expected fixed size, got variable", msg),
+            BCTypeSize::Variable(_) => panic!("{msg}: expected fixed size, got variable"),
         }
     }
 }

--- a/compiler/cx-data-bytecode/src/types.rs
+++ b/compiler/cx-data-bytecode/src/types.rs
@@ -10,6 +10,7 @@ pub enum BCTypeKind {
     Opaque { bytes: usize },
     Signed { bytes: u8 },
     Unsigned { bytes: u8 },
+    Bool,
     Float { bytes: u8 },
     Pointer,
 
@@ -80,6 +81,7 @@ impl BCType {
             BCTypeKind::Opaque { bytes } => *bytes as u8,
             BCTypeKind::Signed { bytes } => *bytes,
             BCTypeKind::Unsigned { bytes } => *bytes,
+            BCTypeKind::Bool => 1,
             BCTypeKind::Float { bytes } => *bytes,
             BCTypeKind::Pointer => 8, // TODO: make this configurable
             BCTypeKind::Array { element, .. } => element.alignment(),

--- a/compiler/cx-exec-data/src/lib.rs
+++ b/compiler/cx-exec-data/src/lib.rs
@@ -35,9 +35,9 @@ pub fn libary_path_prefix() -> String {
         .to_string();
     
     if cfg!(feature = "test") {
-        format!("{}/../../../lib/", path)
+        format!("{path}/../../../lib/")
     } else {
-        format!("{}/../../lib/", path)
+        format!("{path}/../../lib/")
     }
 }
 
@@ -52,6 +52,6 @@ pub fn cx_path_str(path: &str) -> String {
             format!("{}/../../lib/{}.cx", current_exe.parent().unwrap().display(), &path)
         }
     } else {
-        format!("{}.cx", path)
+        format!("{path}.cx")
     }
 }

--- a/compiler/cx-exec-pipeline/src/lib.rs
+++ b/compiler/cx-exec-pipeline/src/lib.rs
@@ -11,7 +11,7 @@ pub fn request_type_compilation(file_paths: &[String]) -> Option<Vec<String>> {
     let mut imports = Vec::new();
     
     for import_path in file_paths.iter() {
-        let internal_path = format!(".internal/{}/.cx-types", import_path);
+        let internal_path = format!(".internal/{import_path}/.cx-types");
         let internal_path = Path::new(&internal_path);
 
         if !internal_path.exists() ||
@@ -20,12 +20,12 @@ pub fn request_type_compilation(file_paths: &[String]) -> Option<Vec<String>> {
             let cx_path_str = cx_path_str(import_path);
             
             imports.extend(
-                module_type_compile(format!(".internal/{}", import_path), cx_path_str)?
+                module_type_compile(format!(".internal/{import_path}"), cx_path_str)?
             );
         } else {
             // If the internal path exists and the source file has not been modified,
             // we can skip recompilation.
-            println!("Skipping recompilation for {}", import_path);
+            println!("Skipping recompilation for {import_path}");
         }
     }
 
@@ -36,7 +36,7 @@ pub fn request_compile(file_paths: &[String], compiler_backend: CompilerBackend,
     let mut imports = Vec::new();
 
     for import_path in file_paths.iter() {
-        let internal_path = format!(".internal/{}/.cx-functions", import_path);
+        let internal_path = format!(".internal/{import_path}/.cx-functions");
         let internal_path = Path::new(&internal_path);
 
         if !internal_path.exists() ||
@@ -45,12 +45,12 @@ pub fn request_compile(file_paths: &[String], compiler_backend: CompilerBackend,
             let cx_path_str = cx_path_str(import_path);
 
             imports.extend(
-                module_compile(format!(".internal/{}", import_path), cx_path_str, compiler_backend, optimization_level)?
+                module_compile(format!(".internal/{import_path}"), cx_path_str, compiler_backend, optimization_level)?
             );
         } else {
             // If the file exists in the internal directory from after compilation began,
             // we can skip recompilation.
-            println!("Skipping recompilation for {}", import_path);
+            println!("Skipping recompilation for {import_path}");
         }
     }
 

--- a/compiler/cx-util/src/format.rs
+++ b/compiler/cx-util/src/format.rs
@@ -3,13 +3,13 @@ use std::io::Write;
 use std::sync::Mutex;
 
 pub fn dump_data(data: &impl std::fmt::Display) {
-    dump_write(&format!("{}\n\n", data));
+    dump_write(&format!("{data}\n\n"));
 }
 
 pub fn dump_all(data: Vec<impl std::fmt::Display>) {
     let data = data
         .into_iter()
-        .map(|d| format!("{}\n", d))
+        .map(|d| format!("{d}\n"))
         .collect::<Vec<String>>()
         .join("\n");
 

--- a/compiler/cx-util/src/scoped_map.rs
+++ b/compiler/cx-util/src/scoped_map.rs
@@ -6,6 +6,12 @@ pub struct ScopedMap<T> {
     overwrites: Vec<Vec<(String, T)>>
 }
 
+impl<T> Default for ScopedMap<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> ScopedMap<T> {
     pub fn new() -> Self {
         Self {

--- a/compiler/cx/src/args.rs
+++ b/compiler/cx/src/args.rs
@@ -68,7 +68,7 @@ pub fn parse_args() -> Result<AppArgs, String> {
                 }
             }
             _ if arg.starts_with('-') => {
-                return Err(format!("Unknown flag: {}", arg));
+                return Err(format!("Unknown flag: {arg}"));
             }
             _ => {
                 if input_file.is_some() {

--- a/compiler/cx/src/main.rs
+++ b/compiler/cx/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
     let args = match args::parse_args() {
         Ok(args) => args,
         Err(err) => {
-            eprintln!("Error: {}", err);
+            eprintln!("Error: {err}");
             std::process::exit(1);
         }
     };

--- a/tests/cases/bool_tests.cx
+++ b/tests/cases/bool_tests.cx
@@ -1,0 +1,7 @@
+int main() {
+    // Weird edge case where Cranelift will struggle with this
+    // since internally a boolean is already an i8, meaning it
+    // is trying to uextend from an i8 to an i8, which causes
+    // an error.
+    i8 convert = (1 == 1);
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,4 @@
 use std::process::Command;
-use std::fs;
 use cx_exec_data::CompilerBackend;
 use cx_exec_pipeline::{debug_compile, standard_compile};
 
@@ -16,7 +15,10 @@ fn run_tests() {
     std::env::set_current_dir(&root).unwrap();
     std::env::set_current_dir("tests/cases").unwrap();
     
-    let cases_dir = fs::read_dir("./").unwrap();
+    std::fs::remove_dir_all(".internal")
+        .unwrap_or_else(|_| {});
+    
+    let cases_dir = std::fs::read_dir("./").unwrap();
 
     for case in cases_dir {
         let case = case.unwrap();
@@ -24,7 +26,7 @@ fn run_tests() {
 
         if path.extension().is_some() && path.extension().unwrap() == "cx" {
             let expected_output_path = path.with_extension("cx-output");
-            let expected_output = fs::read_to_string(&expected_output_path).unwrap_or_else(|_|
+            let expected_output = std::fs::read_to_string(&expected_output_path).unwrap_or_else(|_|
                 panic!("Could not read expected output file: {:?}", expected_output_path)
             );
             
@@ -38,7 +40,7 @@ fn run_tests() {
 
             println!("[{}] Output matches expected output.", path.display());
 
-            fs::remove_file("a.out").unwrap_or_else(|_| {
+            std::fs::remove_file("a.out").unwrap_or_else(|_| {
                 panic!("Could not remove output file: a.out");
             });
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 use cx_exec_data::CompilerBackend;
-use cx_exec_pipeline::{debug_compile, standard_compile};
+use cx_exec_pipeline::debug_compile;
 
 fn get_output() -> String {
     let mut cmd = Command::new("./a.out");
@@ -16,7 +16,7 @@ fn run_tests() {
     std::env::set_current_dir("tests/cases").unwrap();
     
     std::fs::remove_dir_all(".internal")
-        .unwrap_or_else(|_| {});
+        .unwrap_or({});
     
     let cases_dir = std::fs::read_dir("./").unwrap();
 
@@ -27,7 +27,7 @@ fn run_tests() {
         if path.extension().is_some() && path.extension().unwrap() == "cx" {
             let expected_output_path = path.with_extension("cx-output");
             let expected_output = std::fs::read_to_string(&expected_output_path).unwrap_or_else(|_|
-                panic!("Could not read expected output file: {:?}", expected_output_path)
+                panic!("Could not read expected output file: {expected_output_path:?}")
             );
             
             debug_compile(path.to_str().unwrap(), "a.out", CompilerBackend::Cranelift, Default::default());


### PR DESCRIPTION
This pull request refines and optimizes the Cranelift backend code generation in the `compiler/cx-backend-cranelift` module. The changes focus on improving code clarity, removing unused imports, refining type handling, and enhancing code generation for specific virtual instructions. Additionally, several formatting improvements have been made to simplify panic messages and improve readability.

### Code cleanup and import adjustments:
* Removed unused imports, such as `cx_data_ast::parse::value_type::CXTypeKind` and `cx_data_ast::parse::ast::{CXFunctionMap, CXTypeMap}`, across multiple files to improve code clarity. (`[[1]](diffhunk://#diff-5e1b403d250ec1c9447e6d3f1482afc69dcb8f4920ecab8d408fa263d322ea5aL10-R13)`, `[[2]](diffhunk://#diff-d5b770ed01ac432e9cbce8841ec32cce56f81f1c985c715c5a05eafbf2f9958dL8)`, `[[3]](diffhunk://#diff-b0be15e8f5df1abf017f88795e7c2c908659a15b1ba73e3ddb3b848640c6c284L2-L3)`)

### Code generation improvements:
* Added support for the `VirtualInstruction::Phi` instruction, enabling proper handling of block parameters and predecessors in Cranelift's IR. (`[compiler/cx-backend-cranelift/src/instruction.rsR468-R532](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183R468-R532)`)
* Refined handling of `VirtualInstruction::BoolExtend`, `VirtualInstruction::ZExtend`, and `VirtualInstruction::SExtend` to improve type extension logic and ensure correct Cranelift type mapping. (`[compiler/cx-backend-cranelift/src/instruction.rsR541-R574](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183R541-R574)`)

### Simplification and formatting improvements:
* Simplified panic messages by using inline formatting for better readability. For example, `{self:?}` and `{bytes}` are now used directly in panic messages. (`[[1]](diffhunk://#diff-d5b770ed01ac432e9cbce8841ec32cce56f81f1c985c715c5a05eafbf2f9958dL35-R49)`, `[[2]](diffhunk://#diff-d5b770ed01ac432e9cbce8841ec32cce56f81f1c985c715c5a05eafbf2f9958dL153-R152)`, `[[3]](diffhunk://#diff-3cbd83ebbcf1d235f33e23b96e7a94911f4e16eb1c36299cc06640335bbebdf4L40-R40)`, `[[4]](diffhunk://#diff-b0be15e8f5df1abf017f88795e7c2c908659a15b1ba73e3ddb3b848640c6c284L28-R28)`)
* Improved handling of integer types in `get_cranelift_type` by replacing `expect` with `unwrap_or_else` for better error handling. (`[compiler/cx-backend-cranelift/src/value_type.rsR14-R18](diffhunk://#diff-b0be15e8f5df1abf017f88795e7c2c908659a15b1ba73e3ddb3b848640c6c284R14-R18)`)

### Miscellaneous fixes:
* Replaced `.clone()` calls with dereferencing (`*`) where applicable to reduce unnecessary cloning and improve performance. (`[[1]](diffhunk://#diff-5e1b403d250ec1c9447e6d3f1482afc69dcb8f4920ecab8d408fa263d322ea5aL42-R43)`, `[[2]](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183L61-R61)`, `[[3]](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183L84-R85)`, `[[4]](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183L407-R408)`, `[[5]](diffhunk://#diff-59e76241389b965770fb900c77608d4dcd9f47ff34fd2d61d781fd7c01bdc183L421-R421)`)
* Fixed the handling of null-terminated strings by replacing `'* Fixed the handling of null-terminated strings by replacing `'\0' as u8` with `b'\0` for consistency and clarity. (`[compiler/cx-backend-cranelift/src/routines.rsL52-R52](diffhunk://#diff-3cbd83ebbcf1d235f33e23b96e7a94911f4e16eb1c36299cc06640335bbebdf4L52-R52)`)' as u8` with `b'* Fixed the handling of null-terminated strings by replacing `'\0' as u8` with `b'\0` for consistency and clarity. (`[compiler/cx-backend-cranelift/src/routines.rsL52-R52](diffhunk://#diff-3cbd83ebbcf1d235f33e23b96e7a94911f4e16eb1c36299cc06640335bbebdf4L52-R52)`)` for consistency and clarity. (`[compiler/cx-backend-cranelift/src/routines.rsL52-R52](diffhunk://#diff-3cbd83ebbcf1d235f33e23b96e7a94911f4e16eb1c36299cc06640335bbebdf4L52-R52)`)