### PR TITLE
Pointer LLVM Metadata

### DIFF
--- a/compiler/cx-backend-cranelift/src/value_type.rs
+++ b/compiler/cx-backend-cranelift/src/value_type.rs
@@ -23,7 +23,7 @@ pub(crate) fn get_cranelift_type(val_type: &BCType) -> ir::Type {
         BCTypeKind::Float { bytes: 16 }        => ir::types::F128,
         
         BCTypeKind::Struct { .. } |
-        BCTypeKind::Pointer                    => ir::Type::int(64).unwrap(),
+        BCTypeKind::Pointer { .. }             => ir::Type::int(64).unwrap(),
         
         _ => panic!("PANIC: Unsupported type for Cranelift: {val_type:?}"),
     }

--- a/compiler/cx-backend-llvm/src/attributes.rs
+++ b/compiler/cx-backend-llvm/src/attributes.rs
@@ -1,8 +1,23 @@
 use inkwell::attributes::Attribute;
 use inkwell::context::Context;
+use cx_data_bytecode::types::{BCType, BCTypeKind};
 
 pub(crate) fn noundef(context: &Context) -> Attribute {
     context.create_enum_attribute(
         Attribute::get_named_enum_kind_id("noundef"), 1
     )
+}
+
+pub(crate) fn nonnull(context: &Context) -> Attribute {
+    context.create_enum_attribute(
+        Attribute::get_named_enum_kind_id("nonnull"), 1
+    )
+}
+
+pub fn get_type_attributes(context: &Context, _type: &BCType) -> Vec<Attribute> {
+    match _type.kind {
+        BCTypeKind::Pointer { nullable: false } => vec![nonnull(context), noundef(context)],
+        
+        _ => vec![noundef(context)],
+    }
 }

--- a/compiler/cx-backend-llvm/src/attributes.rs
+++ b/compiler/cx-backend-llvm/src/attributes.rs
@@ -2,22 +2,31 @@ use inkwell::attributes::Attribute;
 use inkwell::context::Context;
 use cx_data_bytecode::types::{BCType, BCTypeKind};
 
-pub(crate) fn noundef(context: &Context) -> Attribute {
+pub(crate) fn attr_noundef(context: &Context) -> Attribute {
     context.create_enum_attribute(
         Attribute::get_named_enum_kind_id("noundef"), 1
     )
 }
 
-pub(crate) fn nonnull(context: &Context) -> Attribute {
+pub(crate) fn attr_nonnull(context: &Context) -> Attribute {
     context.create_enum_attribute(
         Attribute::get_named_enum_kind_id("nonnull"), 1
     )
 }
 
+pub(crate) fn attr_dereferenceable(context: &Context, bytes: u64) -> Attribute {
+    context.create_enum_attribute(
+        Attribute::get_named_enum_kind_id("dereferenceable"), bytes
+    )
+}
+
 pub fn get_type_attributes(context: &Context, _type: &BCType) -> Vec<Attribute> {
     match _type.kind {
-        BCTypeKind::Pointer { nullable: false } => vec![nonnull(context), noundef(context)],
+        BCTypeKind::Pointer { nullable: false, dereferenceable: 0 } => 
+            vec![attr_nonnull(context), attr_noundef(context)],
+        BCTypeKind::Pointer { nullable: false, dereferenceable } =>
+            vec![attr_nonnull(context), attr_noundef(context), attr_dereferenceable(context, dereferenceable as u64)],
         
-        _ => vec![noundef(context)],
+        _ => vec![attr_noundef(context)],
     }
 }

--- a/compiler/cx-backend-llvm/src/instruction.rs
+++ b/compiler/cx-backend-llvm/src/instruction.rs
@@ -1,5 +1,5 @@
 use crate::arithmetic::{generate_int_binop, generate_ptr_binop};
-use crate::attributes::noundef;
+use crate::attributes::attr_noundef;
 use crate::mangling::string_literal_name;
 use crate::typing::{any_to_basic_type, any_to_basic_val, bc_llvm_prototype, bc_llvm_type};
 use crate::{CodegenValue, FunctionState, GlobalState};
@@ -124,7 +124,7 @@ pub(crate) fn generate_instruction<'a>(
                 for i in 0..args.len() {
                     val.add_attribute(
                         AttributeLoc::Param(i as u32),
-                        noundef(global_state.context)
+                        attr_noundef(global_state.context)
                     )
                 }
 

--- a/compiler/cx-compiler-ast/src/parse/typing.rs
+++ b/compiler/cx-compiler-ast/src/parse/typing.rs
@@ -278,7 +278,9 @@ pub(crate) fn parse_typemods(data: &mut ParserData, acc_type: CXType) -> Option<
                 specs,
                 CXTypeKind::PointerTo { 
                     inner: Box::new(acc_type),
-                    explicitly_weak: true
+                    
+                    explicitly_weak: true,
+                    nullable: true
                 }
             );
 

--- a/compiler/cx-compiler-bytecode/src/aux_routines.rs
+++ b/compiler/cx-compiler-bytecode/src/aux_routines.rs
@@ -100,7 +100,7 @@ pub(crate) fn allocate_variable(
                     size,
                     alignment: bc_type.alignment(),
                 },
-                BCType::from(BCTypeKind::Pointer { nullable: false })
+                BCType::default_pointer()
             )?
         },
         BCTypeSize::Variable(size_expr) => {
@@ -109,7 +109,7 @@ pub(crate) fn allocate_variable(
                     size: size_expr,
                     alignment: bc_type.alignment(),
                 },
-                BCType::from(BCTypeKind::Pointer { nullable: false })
+                BCType::default_pointer()
             )?
         }
     };

--- a/compiler/cx-compiler-bytecode/src/aux_routines.rs
+++ b/compiler/cx-compiler-bytecode/src/aux_routines.rs
@@ -100,7 +100,7 @@ pub(crate) fn allocate_variable(
                     size,
                     alignment: bc_type.alignment(),
                 },
-                BCTypeKind::Pointer.into()
+                BCType::from(BCTypeKind::Pointer { nullable: false })
             )?
         },
         BCTypeSize::Variable(size_expr) => {
@@ -109,7 +109,7 @@ pub(crate) fn allocate_variable(
                     size: size_expr,
                     alignment: bc_type.alignment(),
                 },
-                BCTypeKind::Pointer.into()
+                BCType::from(BCTypeKind::Pointer { nullable: false })
             )?
         }
     };

--- a/compiler/cx-compiler-bytecode/src/builder.rs
+++ b/compiler/cx-compiler-bytecode/src/builder.rs
@@ -187,7 +187,7 @@ impl BytecodeBuilder {
     ) -> BytecodeResult<ValueID> {
         self.add_instruction_bt(
             VirtualInstruction::FunctionReference { name: name.to_owned() },
-            BCType::from(BCTypeKind::Pointer)
+            BCType::from(BCTypeKind::Pointer { nullable: false })
         )
     }
     

--- a/compiler/cx-compiler-bytecode/src/builder.rs
+++ b/compiler/cx-compiler-bytecode/src/builder.rs
@@ -187,7 +187,7 @@ impl BytecodeBuilder {
     ) -> BytecodeResult<ValueID> {
         self.add_instruction_bt(
             VirtualInstruction::FunctionReference { name: name.to_owned() },
-            BCType::from(BCTypeKind::Pointer { nullable: false })
+            BCType::default_pointer()
         )
     }
     

--- a/compiler/cx-compiler-bytecode/src/cx_maps.rs
+++ b/compiler/cx-compiler-bytecode/src/cx_maps.rs
@@ -263,10 +263,13 @@ pub(crate) fn convert_fixed_type_kind(cx_type_map: &CXTypeMap, cx_type_kind: &CX
             CXTypeKind::Float { bytes } =>
                 BCTypeKind::Float { bytes: *bytes },
 
-            CXTypeKind::StrongPointer { .. } |
+            CXTypeKind::PointerTo { nullable: false, .. } |
+            CXTypeKind::StrongPointer { .. } =>
+                BCTypeKind::Pointer { nullable: false },
+            
             CXTypeKind::Function { .. } |
-            CXTypeKind::PointerTo { .. } =>
-                BCTypeKind::Pointer,
+            CXTypeKind::PointerTo { nullable: true, .. } =>
+                BCTypeKind::Pointer { nullable: true },
             
             CXTypeKind::Array { _type, size } =>
                 BCTypeKind::Array {
@@ -279,7 +282,7 @@ pub(crate) fn convert_fixed_type_kind(cx_type_map: &CXTypeMap, cx_type_kind: &CX
                     CXTypeKind::Structured { .. } => convert_fixed_type_kind(cx_type_map, &inner.kind)?,
                     CXTypeKind::Union { .. } => convert_fixed_type_kind(cx_type_map, &inner.kind)?,
                     
-                    _ => BCTypeKind::Pointer
+                    _ => BCTypeKind::Pointer { nullable: true }
                 }
             },
             

--- a/compiler/cx-compiler-bytecode/src/deconstructor.rs
+++ b/compiler/cx-compiler-bytecode/src/deconstructor.rs
@@ -22,7 +22,7 @@ fn deconstructor_prototype(type_: &CXType) -> BCFunctionPrototype {
         name: deconstructor_name,
         return_type: BCType::unit(),
         params: vec![
-            BCParameter { name: None, _type: BCType::from(BCTypeKind::Pointer) }
+            BCParameter { name: None, _type: BCType::from(BCTypeKind::Pointer { nullable: false }) }
         ],
         var_args: false,
     }
@@ -41,7 +41,7 @@ fn load_mem(
         VirtualInstruction::Load {
             value: val,
         },
-        BCType::from(BCTypeKind::Pointer)
+        BCType::from(BCTypeKind::Pointer { nullable: false })
     )
 }
 
@@ -60,7 +60,7 @@ fn if_owned_call(
         VirtualInstruction::IntToPtr {
             value: zero
         },
-        BCType::from(BCTypeKind::Pointer)
+        BCType::from(BCTypeKind::Pointer { nullable: false })
     )?;
 
     let nonnull = builder.add_instruction_bt(
@@ -151,7 +151,7 @@ pub fn deconstruct_variable(
                     VirtualInstruction::GetFunctionAddr {
                         func: deconstructor,
                     },
-                    BCType::from(BCTypeKind::Pointer)
+                    BCType::from(BCTypeKind::Pointer { nullable: false })
                 )?;
                 
                 if_owned_call(
@@ -183,7 +183,7 @@ pub fn deconstruct_variable(
                     VirtualInstruction::FunctionReference {
                         name: mangle_destructor(name),
                     },
-                    BCType::from(BCTypeKind::Pointer)
+                    BCType::from(BCTypeKind::Pointer { nullable: false })
                 )?;
                 
                 builder.add_instruction(
@@ -246,7 +246,7 @@ pub fn generate_deconstructor(
 
     let struct_val = builder.add_instruction_bt(
         VirtualInstruction::FunctionParameter { param_index: 0 },
-        BCType::from(BCTypeKind::Pointer)
+        BCType::from(BCTypeKind::Pointer { nullable: false })
     )?;
     
     if let Some(name) = data._type.get_destructor(&builder.cx_type_map) {

--- a/compiler/cx-compiler-bytecode/src/deconstructor.rs
+++ b/compiler/cx-compiler-bytecode/src/deconstructor.rs
@@ -17,12 +17,13 @@ fn deconstructor_name(type_: &CXType) -> String {
 
 fn deconstructor_prototype(type_: &CXType) -> BCFunctionPrototype {
     let deconstructor_name = deconstructor_name(type_);
+    let this_param_type = BCType::from(BCTypeKind::Pointer { nullable: false, dereferenceable: 0 });
 
     BCFunctionPrototype {
         name: deconstructor_name,
         return_type: BCType::unit(),
         params: vec![
-            BCParameter { name: None, _type: BCType::from(BCTypeKind::Pointer { nullable: false }) }
+            BCParameter { name: None, _type: this_param_type },
         ],
         var_args: false,
     }
@@ -41,7 +42,7 @@ fn load_mem(
         VirtualInstruction::Load {
             value: val,
         },
-        BCType::from(BCTypeKind::Pointer { nullable: false })
+        BCType::default_pointer()
     )
 }
 
@@ -60,7 +61,7 @@ fn if_owned_call(
         VirtualInstruction::IntToPtr {
             value: zero
         },
-        BCType::from(BCTypeKind::Pointer { nullable: false })
+        BCType::default_pointer()
     )?;
 
     let nonnull = builder.add_instruction_bt(
@@ -151,7 +152,7 @@ pub fn deconstruct_variable(
                     VirtualInstruction::GetFunctionAddr {
                         func: deconstructor,
                     },
-                    BCType::from(BCTypeKind::Pointer { nullable: false })
+                    BCType::default_pointer()
                 )?;
                 
                 if_owned_call(
@@ -183,7 +184,7 @@ pub fn deconstruct_variable(
                     VirtualInstruction::FunctionReference {
                         name: mangle_destructor(name),
                     },
-                    BCType::from(BCTypeKind::Pointer { nullable: false })
+                    BCType::default_pointer()
                 )?;
                 
                 builder.add_instruction(
@@ -246,7 +247,7 @@ pub fn generate_deconstructor(
 
     let struct_val = builder.add_instruction_bt(
         VirtualInstruction::FunctionParameter { param_index: 0 },
-        BCType::from(BCTypeKind::Pointer { nullable: false })
+        BCType::default_pointer()
     )?;
     
     if let Some(name) = data._type.get_destructor(&builder.cx_type_map) {

--- a/compiler/cx-compiler-bytecode/src/global_stmts.rs
+++ b/compiler/cx-compiler-bytecode/src/global_stmts.rs
@@ -46,7 +46,7 @@ pub(crate) fn generate_destructor(
         VirtualInstruction::FunctionParameter {
             param_index: 0,
         },
-        BCType::from(BCTypeKind::Pointer)
+        BCType::from(BCTypeKind::Pointer { nullable: false })
     )?;
 
     builder.symbol_table.insert("this".to_string(), this);

--- a/compiler/cx-compiler-bytecode/src/global_stmts.rs
+++ b/compiler/cx-compiler-bytecode/src/global_stmts.rs
@@ -46,7 +46,7 @@ pub(crate) fn generate_destructor(
         VirtualInstruction::FunctionParameter {
             param_index: 0,
         },
-        BCType::from(BCTypeKind::Pointer { nullable: false })
+        BCType::default_pointer()
     )?;
 
     builder.symbol_table.insert("this".to_string(), this);

--- a/compiler/cx-compiler-bytecode/src/instruction_gen.rs
+++ b/compiler/cx-compiler-bytecode/src/instruction_gen.rs
@@ -249,7 +249,7 @@ pub fn generate_instruction(
                 VirtualInstruction::StringLiteral {
                     str_id: string_id,
                 },
-                BCType::from(BCTypeKind::Pointer)
+                BCType::from(BCTypeKind::Pointer { nullable: false })
             )
         },
 
@@ -601,7 +601,7 @@ pub fn generate_instruction(
                 VirtualInstruction::Load {
                     value: memory
                 },
-                BCType::from(BCTypeKind::Pointer)
+                BCType::from(BCTypeKind::Pointer { nullable: false })
             )?;
             
             let zero = builder.int_const(0, 8, true)?;
@@ -616,7 +616,7 @@ pub fn generate_instruction(
                 VirtualInstruction::Store {
                     memory,
                     value: zero_as_ptr,
-                    type_: BCType::from(BCTypeKind::Pointer)
+                    type_: BCType::from(BCTypeKind::Pointer { nullable: false })
                 },
                 CXType::unit()
             )?;
@@ -645,7 +645,7 @@ pub fn generate_instruction(
                             args: vec![size_imm, len],
                             method_sig: builder.fn_map.get(STANDARD_ARRAY_ALLOC).unwrap().clone(),
                         },
-                        BCType::from(BCTypeKind::Pointer)
+                        BCType::from(BCTypeKind::Pointer { nullable: false })
                     )
                 },
                 
@@ -659,7 +659,7 @@ pub fn generate_instruction(
                             args: vec![size_imm],
                             method_sig: builder.fn_map.get(STANDARD_ALLOC).unwrap().clone(),
                         },
-                        BCType::from(BCTypeKind::Pointer)
+                        BCType::from(BCTypeKind::Pointer { nullable: false })
                     )
                 },
             }
@@ -802,7 +802,7 @@ pub(crate) fn generate_algebraic_binop(
             )
         },
 
-        BCTypeKind::Pointer => {
+        BCTypeKind::Pointer { .. } => {
             let CXTypeKind::PointerTo { inner: left_inner, .. }
                 = &cx_lhs_type.intrinsic_type_kind(&builder.cx_type_map)?
             else { 

--- a/compiler/cx-compiler-bytecode/src/instruction_gen.rs
+++ b/compiler/cx-compiler-bytecode/src/instruction_gen.rs
@@ -249,7 +249,7 @@ pub fn generate_instruction(
                 VirtualInstruction::StringLiteral {
                     str_id: string_id,
                 },
-                BCType::from(BCTypeKind::Pointer { nullable: false })
+                BCType::default_pointer()
             )
         },
 
@@ -601,7 +601,7 @@ pub fn generate_instruction(
                 VirtualInstruction::Load {
                     value: memory
                 },
-                BCType::from(BCTypeKind::Pointer { nullable: false })
+                BCType::default_pointer()
             )?;
             
             let zero = builder.int_const(0, 8, true)?;
@@ -616,7 +616,7 @@ pub fn generate_instruction(
                 VirtualInstruction::Store {
                     memory,
                     value: zero_as_ptr,
-                    type_: BCType::from(BCTypeKind::Pointer { nullable: false })
+                    type_: BCType::default_pointer()
                 },
                 CXType::unit()
             )?;
@@ -645,7 +645,7 @@ pub fn generate_instruction(
                             args: vec![size_imm, len],
                             method_sig: builder.fn_map.get(STANDARD_ARRAY_ALLOC).unwrap().clone(),
                         },
-                        BCType::from(BCTypeKind::Pointer { nullable: false })
+                        BCType::default_pointer()
                     )
                 },
                 
@@ -659,7 +659,7 @@ pub fn generate_instruction(
                             args: vec![size_imm],
                             method_sig: builder.fn_map.get(STANDARD_ALLOC).unwrap().clone(),
                         },
-                        BCType::from(BCTypeKind::Pointer { nullable: false })
+                        BCType::default_pointer()
                     )
                 },
             }

--- a/compiler/cx-compiler-typechecker/src/checker.rs
+++ b/compiler/cx-compiler-typechecker/src/checker.rs
@@ -519,7 +519,9 @@ pub(crate) fn coerce_value(
                     expr_type.specifiers,
                     CXTypeKind::PointerTo {
                         inner: inner.clone(),
-                        explicitly_weak: false
+                        
+                        explicitly_weak: false,
+                        nullable: true,
                     }
                 )
             ),

--- a/compiler/cx-compiler-typechecker/src/global_stmts.rs
+++ b/compiler/cx-compiler-typechecker/src/global_stmts.rs
@@ -14,9 +14,18 @@ pub(crate) fn add_destructor_prototypes(
         if let Some(name) = _type.get_destructor(type_map) {
             let destructor_name = mangle_destructor(name);
             
+            let this_type = CXType::new(
+                0,
+                CXTypeKind::PointerTo {
+                    inner: Box::new(_type.clone()),
+                    explicitly_weak: true,
+                    nullable: false,
+                },
+            );
+            
             let prototype = CXFunctionPrototype {
                 name: CXIdent::from_owned(destructor_name.clone()),
-                params: vec![CXParameter { name: None, type_: _type.clone().pointer_to() }],
+                params: vec![CXParameter { name: None, type_: this_type }],
                 return_type: CXType::unit(),
                 var_args: false
             };

--- a/compiler/cx-data-ast/src/parse/format.rs
+++ b/compiler/cx-data-ast/src/parse/format.rs
@@ -274,11 +274,20 @@ impl Display for CXTypeKind {
                 write!(f, "union {name_str} {{ {field_strs} }}")
             },
             CXTypeKind::Unit => write!(f, "()"),
-            CXTypeKind::PointerTo { inner, explicitly_weak: false } => {
-                write!(f, "{inner}*")
-            },
-            CXTypeKind::PointerTo { inner, explicitly_weak: true } => {
-                write!(f, "{inner} weak*")
+            CXTypeKind::PointerTo { inner, explicitly_weak, nullable } => {
+                write!(f, "{inner} ")?;
+                
+                if *explicitly_weak {
+                    write!(f, "weak")?;
+                }
+                
+                write!(f, "*")?;
+                
+                if *nullable {
+                    write!(f, " (nonnull)")
+                } else {
+                    Ok(())
+                }
             },
             CXTypeKind::StrongPointer { inner, .. } => {
                 write!(f, "{inner} strong*")

--- a/compiler/cx-data-ast/src/parse/value_type.rs
+++ b/compiler/cx-data-ast/src/parse/value_type.rs
@@ -49,7 +49,9 @@ pub enum CXTypeKind {
 
     PointerTo {
         inner: Box<CXType>,
-        explicitly_weak: bool
+        
+        explicitly_weak: bool,
+        nullable: bool
     },
     MemoryAlias(Box<CXType>),
     Array {
@@ -226,7 +228,9 @@ impl CXType {
             specifiers: 0,
             kind: CXTypeKind::PointerTo {
                 inner: Box::new(self),
-                explicitly_weak: false
+                
+                explicitly_weak: false,
+                nullable: true
             }
         }
     }

--- a/compiler/cx-data-bytecode/src/format.rs
+++ b/compiler/cx-data-bytecode/src/format.rs
@@ -354,8 +354,10 @@ impl Display for BCTypeKind {
             BCTypeKind::Unsigned { bytes } => write!(f, "u{}", bytes * 8),
             BCTypeKind::Bool => write!(f, "bool"),
             BCTypeKind::Float { bytes } => write!(f, "f{}", bytes * 8),
-            BCTypeKind::Pointer => write!(f, "*"),
-
+            
+            BCTypeKind::Pointer { nullable: false } => write!(f, "!*"),
+            BCTypeKind::Pointer { nullable: true } => write!(f, "*"),
+            
             BCTypeKind::Array { element, size } => {
                 write!(f, "[{element}; {size}]")
             },

--- a/compiler/cx-data-bytecode/src/format.rs
+++ b/compiler/cx-data-bytecode/src/format.rs
@@ -355,8 +355,19 @@ impl Display for BCTypeKind {
             BCTypeKind::Bool => write!(f, "bool"),
             BCTypeKind::Float { bytes } => write!(f, "f{}", bytes * 8),
             
-            BCTypeKind::Pointer { nullable: false } => write!(f, "!*"),
-            BCTypeKind::Pointer { nullable: true } => write!(f, "*"),
+            BCTypeKind::Pointer { nullable, dereferenceable } => {
+                if !*nullable {
+                    write!(f, "!")?;
+                }
+                
+                write!(f, "*")?;
+                
+                if *dereferenceable > 0 {
+                    write!(f, " (deref: {dereferenceable})")
+                } else {
+                    Ok(())
+                }
+            },
             
             BCTypeKind::Array { element, size } => {
                 write!(f, "[{element}; {size}]")

--- a/compiler/cx-data-bytecode/src/types.rs
+++ b/compiler/cx-data-bytecode/src/types.rs
@@ -20,7 +20,7 @@ pub enum BCTypeKind {
     Unsigned { bytes: u8 },
     Bool,
     Float { bytes: u8 },
-    Pointer,
+    Pointer { nullable: bool },
 
     Array { element: Box<BCType>, size: usize },
     Struct { name: String, fields: Vec<(String, BCType)> },
@@ -66,7 +66,7 @@ impl BCType {
             BCTypeKind::Signed { bytes } => *bytes as usize,
             BCTypeKind::Unsigned { bytes } => *bytes as usize,
             BCTypeKind::Float { bytes } => *bytes as usize,
-            BCTypeKind::Pointer => 8, // TODO: make this configurable
+            BCTypeKind::Pointer { .. } => 8, // TODO: make this configurable
             BCTypeKind::Array { element, size } =>
                 element.fixed_size() * size,
             BCTypeKind::Struct { fields, .. }
@@ -107,7 +107,7 @@ impl BCType {
             BCTypeKind::Unsigned { bytes } => *bytes,
             BCTypeKind::Bool => 1,
             BCTypeKind::Float { bytes } => *bytes,
-            BCTypeKind::Pointer => 8, // TODO: make this configurable
+            BCTypeKind::Pointer { .. } => 8, // TODO: make this configurable
             BCTypeKind::Array { element, .. } => element.alignment(),
             BCTypeKind::Struct { fields, .. }
                 => fields.iter().map(|(_, field)| field.alignment()).max().unwrap_or(1),

--- a/compiler/cx-data-bytecode/src/types.rs
+++ b/compiler/cx-data-bytecode/src/types.rs
@@ -11,6 +11,12 @@ impl BCType {
             kind: BCTypeKind::Unit
         }
     }
+    
+    pub fn default_pointer() -> Self {
+        BCType {
+            kind: BCTypeKind::Pointer { nullable: false, dereferenceable: 0 }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -20,7 +26,7 @@ pub enum BCTypeKind {
     Unsigned { bytes: u8 },
     Bool,
     Float { bytes: u8 },
-    Pointer { nullable: bool },
+    Pointer { nullable: bool, dereferenceable: u32 },
 
     Array { element: Box<BCType>, size: usize },
     Struct { name: String, fields: Vec<(String, BCType)> },

--- a/example_code/basic_strong_ptr.cx
+++ b/example_code/basic_strong_ptr.cx
@@ -9,12 +9,18 @@ struct strong_ptr_container {
     printf("~strong_ptr_container\n");
 }
 
+void take(strong_ptr_container strong* container) {
+    printf("taken\n");
+}
+
 int main() {
     int strong* ptr = new int;
     int strong[] ptr2 = new int[2];
     int strong* reassign_ptr = new int;
     reassign_ptr = new int;
     int strong* ptr_moved = move ptr;
+
+    take(move ptr_moved);
 
     strong_ptr_container container;
     container.ptr = new int;


### PR DESCRIPTION
This pull request introduces significant improvements and refactoring to the handling of pointer types and attribute generation across multiple compiler backend modules. The changes implement more precise definitions for nullable and dereferenceable pointer types, streamline attribute handling, and replace redundant code with reusable methods. These updates enhance type safety, simplify code maintenance, and improve the overall clarity of the codebase.

### Pointer Type Enhancements:
* Updated `BCTypeKind::Pointer` to include `nullable` and `dereferenceable` fields, enabling more precise representation of pointer types. (`compiler/cx-backend-cranelift/src/value_type.rs` - [[1]](diffhunk://#diff-b0be15e8f5df1abf017f88795e7c2c908659a15b1ba73e3ddb3b848640c6c284L26-R26) `compiler/cx-backend-llvm/src/typing.rs` - [[2]](diffhunk://#diff-b21999d492df88f214816db52d3c0edb82cc1f30ae01fae9a5d761bcb9f42d5dL86-R67) [[3]](diffhunk://#diff-b21999d492df88f214816db52d3c0edb82cc1f30ae01fae9a5d761bcb9f42d5dL125-R137)
* Replaced direct usage of `BCTypeKind::Pointer` with `BCType::default_pointer()` for consistent default pointer type creation. (`compiler/cx-compiler-bytecode/src/aux_routines.rs` - [[1]](diffhunk://#diff-f38276cca1bfb91ad8f4f1f5a1006c247805b5a323a594eaab8cae7184dd152eL103-R103) [[2]](diffhunk://#diff-f38276cca1bfb91ad8f4f1f5a1006c247805b5a323a594eaab8cae7184dd152eL112-R112) `compiler/cx-compiler-bytecode/src/deconstructor.rs` - [[3]](diffhunk://#diff-407c7a277ed9e8be8c0f4d84db8ac757f85180898b868c896650d65fb2a4647dL44-R45) [[4]](diffhunk://#diff-407c7a277ed9e8be8c0f4d84db8ac757f85180898b868c896650d65fb2a4647dL63-R64) [[5]](diffhunk://#diff-407c7a277ed9e8be8c0f4d84db8ac757f85180898b868c896650d65fb2a4647dL154-R155) [[6]](diffhunk://#diff-407c7a277ed9e8be8c0f4d84db8ac757f85180898b868c896650d65fb2a4647dL186-R187) [[7]](diffhunk://#diff-407c7a277ed9e8be8c0f4d84db8ac757f85180898b868c896650d65fb2a4647dL249-R250) `compiler/cx-compiler-bytecode/src/global_stmts.rs` - [[8]](diffhunk://#diff-452a86109b5c104838a840c4bbb29be675ec632711283cc8401dadda7cd89204L49-R49) `compiler/cx-compiler-bytecode/src/instruction_gen.rs` - [[9]](diffhunk://#diff-01d319ffc91453a826ad60fdf8dedf89cae7311426e747a831115aa165058656L252-R252) [[10]](diffhunk://#diff-01d319ffc91453a826ad60fdf8dedf89cae7311426e747a831115aa165058656L604-R604) [[11]](diffhunk://#diff-01d319ffc91453a826ad60fdf8dedf89cae7311426e747a831115aa165058656L619-R619)

### Attribute Handling Improvements:
* Added new functions `attr_nonnull`, `attr_dereferenceable`, and `get_type_attributes` to generate LLVM attributes for pointer types based on their properties. (`compiler/cx-backend-llvm/src/attributes.rs` - [compiler/cx-backend-llvm/src/attributes.rsR3-R32](diffhunk://#diff-3561fc58a36c2ed2855eef78c4e15ef0de7c0c9851afdf094446ffdaa8647126R3-R32))
* Updated existing code to use `get_type_attributes` for attaching attributes to function parameters, replacing hardcoded `noundef` attributes. (`compiler/cx-backend-llvm/src/lib.rs` - [[1]](diffhunk://#diff-4ca9aabce8e7f8a53026e0bc5ca1e933c703d3d83ed78f67fc03bcee755d58b3L313-R319) `compiler/cx-backend-llvm/src/instruction.rs` - [[2]](diffhunk://#diff-757e36b5940f4511ca03fd1b946a8927c3bbae5d3e966d863a0543e45a6d017cL127-R127)

### Function Prototype Refactoring:
* Refactored `bc_llvm_prototype` to directly construct function prototypes without relying on the removed `create_fn_proto` helper, simplifying the code and improving readability. (`compiler/cx-backend-llvm/src/typing.rs` - [compiler/cx-backend-llvm/src/typing.rsL125-R137](diffhunk://#diff-b21999d492df88f214816db52d3c0edb82cc1f30ae01fae9a5d761bcb9f42d5dL125-R137))
* Removed redundant `cx_llvm_prototype` function as its functionality was merged into `bc_llvm_prototype`. (`compiler/cx-backend-llvm/src/typing.rs` - [compiler/cx-backend-llvm/src/typing.rsL125-R137](diffhunk://#diff-b21999d492df88f214816db52d3c0edb82cc1f30ae01fae9a5d761bcb9f42d5dL125-R137))

### Struct Type Enhancements:
* Improved handling of anonymous and named structures by consolidating logic for struct name generation and definition creation. (`compiler/cx-backend-llvm/src/typing.rs` - [compiler/cx-backend-llvm/src/typing.rsL107-R95](diffhunk://#diff-b21999d492df88f214816db52d3c0edb82cc1f30ae01fae9a5d761bcb9f42d5dL107-R95))

### Miscellaneous Adjustments:
* Updated imports and variable names for consistency and clarity across files. (`compiler/cx-backend-llvm/src/lib.rs` - [[1]](diffhunk://#diff-4ca9aabce8e7f8a53026e0bc5ca1e933c703d3d83ed78f67fc03bcee755d58b3L3-R3) [[2]](diffhunk://#diff-4ca9aabce8e7f8a53026e0bc5ca1e933c703d3d83ed78f67fc03bcee755d58b3R16) [[3]](diffhunk://#diff-4ca9aabce8e7f8a53026e0bc5ca1e933c703d3d83ed78f67fc03bcee755d58b3L302-R303)
* Enhanced `convert_fixed_type_kind` to handle nullable and dereferenceable pointer types more accurately during type conversion. (`compiler/cx-compiler-bytecode/src/cx_maps.rs` - [[1]](diffhunk://#diff-c6dc9fa367ae95c39651d9cedf477e9715a46d79e5c067761738e3c7a3da111bL266-R278) [[2]](diffhunk://#diff-c6dc9fa367ae95c39651d9cedf477e9715a46d79e5c067761738e3c7a3da111bL282-R291)