### PR TITLE
Rudimentary Tagged Union Support, Improved Coercion Rules, and TCAST Display Support

### DIFF
--- a/compiler/cx-backend-cranelift/src/codegen.rs
+++ b/compiler/cx-backend-cranelift/src/codegen.rs
@@ -6,6 +6,7 @@ use cranelift::codegen::ir::{Function, UserFuncName};
 use cranelift::prelude::{FunctionBuilder, FunctionBuilderContext, Signature};
 use cranelift_module::{FuncId, Module};
 use cx_data_bytecode::{BCFunctionPrototype, BlockID, BytecodeFunction, ElementID, FunctionBlock, MIRValue};
+use cx_util::format::dump_data;
 use crate::routines::convert_linkage;
 
 pub(crate) fn codegen_fn_prototype(global_state: &mut GlobalState, prototype: &BCFunctionPrototype) -> Option<()> {
@@ -101,6 +102,8 @@ pub(crate) fn codegen_function(global_state: &mut GlobalState, func_id: FuncId, 
     context.builder.finalize();
 
     let GlobalState { object_module, context, .. } = global_state;
+
+    dump_data(&func);
 
     context.func = func;
     object_module

--- a/compiler/cx-backend-llvm/src/lib.rs
+++ b/compiler/cx-backend-llvm/src/lib.rs
@@ -278,6 +278,8 @@ fn codegen_block<'a>(
     function_state.builder.position_at_end(block_val);
 
     for (value_id, inst) in block.body.iter().enumerate() {
+        println!("Generating instruction: {inst}");
+
         let Some(value) = instruction::generate_instruction(
             global_state,
             function_state,

--- a/compiler/cx-backend-llvm/src/typing.rs
+++ b/compiler/cx-backend-llvm/src/typing.rs
@@ -84,11 +84,6 @@ pub(crate) fn bc_llvm_type<'a>(context: &'a Context, _type: &BCType) -> Option<A
                     })
                     .collect::<Option<Vec<_>>>()?;
 
-                let struct_type = context.struct_type(
-                    _types.as_slice(),
-                    false
-                );
-
                 let struct_name = if name.is_empty() {
                     anonymous_struct_name()
                 } else {
@@ -101,10 +96,13 @@ pub(crate) fn bc_llvm_type<'a>(context: &'a Context, _type: &BCType) -> Option<A
                 return context.get_struct_type(struct_name.as_str())
                     .map(|s| s.as_any_type_enum());
             }
-            BCTypeKind::Union { name, .. } =>
-                context.get_struct_type(name.as_str())
-                    .unwrap_or_else(|| context.opaque_struct_type(name.as_str()))
-                    .as_any_type_enum(),
+
+            BCTypeKind::Union { .. } => {
+                let _type_size = _type.fixed_size();
+                let array_type = context.i8_type().array_type(_type_size as u32);
+
+                array_type.as_any_type_enum()
+            },
 
             _ => panic!("Invalid type: {_type:?}")
         }

--- a/compiler/cx-compiler-ast/src/parse/operators.rs
+++ b/compiler/cx-compiler-ast/src/parse/operators.rs
@@ -31,7 +31,7 @@ impl PrecOperator {
 
 pub(crate) fn binop_prec(op: CXBinOp) -> u8 {
     match op {
-        CXBinOp::Access | CXBinOp::MethodCall | CXBinOp::ArrayIndex => 1,
+        CXBinOp::Access | CXBinOp::MethodCall | CXBinOp::ArrayIndex | CXBinOp::Is => 1,
         CXBinOp::Multiply | CXBinOp::Divide | CXBinOp::Modulus => 4,
         CXBinOp::Add | CXBinOp::Subtract => 5,
 
@@ -156,6 +156,8 @@ fn op_to_binop(op: OperatorType) -> Option<CXBinOp> {
             
             OperatorType::DoubleLT          => CXBinOp::LShift,
             OperatorType::DoubleGT          => CXBinOp::RShift,
+
+            OperatorType::Is                => CXBinOp::Is,
 
             _ => log_error!("PARSER ERROR: Invalid binary operator: {:?}", op)
         }

--- a/compiler/cx-compiler-bytecode/src/aux_routines.rs
+++ b/compiler/cx-compiler-bytecode/src/aux_routines.rs
@@ -1,4 +1,4 @@
-use cx_data_ast::parse::ast::{CXExpr, CXExprKind};
+use cx_data_ast::parse::ast::{CXBinOp, CXExpr, CXExprKind};
 use cx_data_typechecker::cx_types::{CXType, CXTypeKind};
 use cx_data_bytecode::{MIRValue, VirtualInstruction};
 use cx_data_bytecode::types::{BCType, BCTypeKind};
@@ -7,6 +7,8 @@ use cx_util::bytecode_error_log;
 use cx_util::mangling::{mangle_destructor};
 use crate::builder::{BytecodeBuilder, DeclarationLifetime};
 use crate::BytecodeResult;
+use crate::deconstructor::deconstruct_variable;
+use crate::instruction_gen::generate_instruction;
 
 pub(crate) struct CXStructAccess {
     pub(crate) offset: usize,
@@ -159,4 +161,21 @@ pub(crate) fn allocate_variable(
     }
 
     Some(memory)
+}
+
+pub(crate) fn assign_value(builder: &mut BytecodeBuilder, target: MIRValue, source: MIRValue, _type: &CXType, additional_op: Option<&CXBinOp>)
+    -> BytecodeResult<MIRValue> {
+
+    if additional_op.is_some() { todo!("compound assignment") }
+
+    let inner_type = builder.convert_fixed_cx_type(&_type)?;
+
+    builder.add_instruction(
+        VirtualInstruction::Store {
+            memory: target,
+            value: source,
+            type_: inner_type,
+        },
+        BCType::unit()
+    )
 }

--- a/compiler/cx-compiler-bytecode/src/builder.rs
+++ b/compiler/cx-compiler-bytecode/src/builder.rs
@@ -534,4 +534,23 @@ impl BytecodeBuilder {
             access._type.clone()
         )
     }
+
+    pub fn get_tag(&mut self, val: &MIRValue, _type: &BCType) -> Option<MIRValue> {
+        self.struct_access(val.clone(), _type, 1)
+    }
+
+    pub fn set_tag(&mut self, val: &MIRValue, _type: &BCType, tag: u32) -> Option<MIRValue> {
+        let tag_val = self.int_const(tag as i32, 4, true);
+        let tag_field = self.get_tag(val, _type)?;
+
+        self.add_instruction(
+            VirtualInstruction::Store {
+                memory: tag_field,
+                value: tag_val,
+
+                type_: BCType::from(BCTypeKind::Unsigned { bytes: 4 })
+            },
+            BCType::unit()
+        )
+    }
 }

--- a/compiler/cx-compiler-bytecode/src/cx_maps.rs
+++ b/compiler/cx-compiler-bytecode/src/cx_maps.rs
@@ -128,12 +128,13 @@ fn convert_fixed_type(cx_type: &CXType) -> Option<BCType> {
 }
 
 fn convert_argument_type(cx_type: &CXType) -> Option<BCType> {
-    match &cx_type.kind {
-        CXTypeKind::Structured { .. } | CXTypeKind::Union { .. } => {
-            Some(BCType::default_pointer())
-        },
-        
-        _ => convert_fixed_type(cx_type)
+    let bc_type = convert_fixed_type(cx_type)?;
+
+    match &bc_type.kind {
+        BCTypeKind::Struct { .. } | BCTypeKind::Union { .. }
+            => Some(BCType::default_pointer()),
+
+        _ => Some(bc_type)
     }
 }
 

--- a/compiler/cx-compiler-bytecode/src/deconstructor.rs
+++ b/compiler/cx-compiler-bytecode/src/deconstructor.rs
@@ -53,7 +53,7 @@ pub fn deconstruct_variable(builder: &mut BytecodeBuilder, var: &MIRValue, _type
         CXTypeKind::StrongPointer { inner_type, is_array } => {
             let deconstructor = builder.get_deconstructor(inner_type);
 
-            let inner_val = MIRValue::LoadOf(BCType::default_pointer(), Box::new(var.clone()));
+            let inner_val = builder.load_value(var.clone(), BCType::default_pointer())?;
             let deconstruct = builder.create_named_block("ptr_not_null");
             let post_deconstruct = builder.create_named_block("ptr_is_null");
 

--- a/compiler/cx-compiler-bytecode/src/implicit_cast.rs
+++ b/compiler/cx-compiler-bytecode/src/implicit_cast.rs
@@ -189,11 +189,11 @@ pub(crate) fn implicit_cast(
 
         CXCastType::Load => {
             let new_type = builder.convert_cx_type(to_type)?;
-            Some(MIRValue::LoadOf(new_type, Box::new(value)))
+            builder.load_value(value, new_type)
         }
         
-        CXCastType::FauxLoad => {
+        CXCastType::Reinterpret => {
             Some(value)
-        },
+        }
     }
 }

--- a/compiler/cx-compiler-bytecode/src/implicit_cast.rs
+++ b/compiler/cx-compiler-bytecode/src/implicit_cast.rs
@@ -186,6 +186,11 @@ pub(crate) fn implicit_cast(
                 to_type.clone()
             )
         },
+
+        CXCastType::Load => {
+            let new_type = builder.convert_cx_type(to_type)?;
+            Some(MIRValue::LoadOf(new_type, Box::new(value)))
+        }
         
         CXCastType::FauxLoad => {
             Some(value)

--- a/compiler/cx-compiler-lexer/src/lex/lexer.rs
+++ b/compiler/cx-compiler-lexer/src/lex/lexer.rs
@@ -1,4 +1,5 @@
 use std::io::BufRead;
+use cx_data_lexer::punctuator;
 use cx_data_lexer::token::{OperatorType, PunctuatorType, Token, TokenKind};
 use cx_util::char_iter::CharIter;
 
@@ -327,6 +328,10 @@ fn operator_lex(iter: &mut CharIter) -> Option<Token> {
             Some('=') => {
                 iter.next();
                 Some(TokenKind::Operator(OperatorType::Equal))
+            },
+            Some('>') => {
+                iter.next();
+                Some(punctuator!(ThickArrow))
             },
             _ => Some(TokenKind::Assignment(None))
         },

--- a/compiler/cx-compiler-typechecker/src/binary_ops.rs
+++ b/compiler/cx-compiler-typechecker/src/binary_ops.rs
@@ -226,7 +226,7 @@ pub(crate) fn typecheck_method_call(env: &mut TCEnvironment, lhs: &CXExpr, rhs: 
             },
 
             CXTypeKind::Float { bytes: 8 } => {
-                add_coercion(arg, CXTypeKind::Integer { bytes: 8, signed: false }.into(), CXCastType::BitCast);
+                // Already the correct type for varargs
             },
 
             CXTypeKind::Bool => {

--- a/compiler/cx-compiler-typechecker/src/binary_ops.rs
+++ b/compiler/cx-compiler-typechecker/src/binary_ops.rs
@@ -204,12 +204,12 @@ pub(crate) fn typecheck_method_call(env: &mut TCEnvironment, lhs: &CXExpr, rhs: 
 
     // Standard argument coercion
     for (arg, param) in tc_args.iter_mut().zip(prototype.params.iter()) {
-        coerce_value(arg);
         implicit_cast(arg, &param._type)?;
     }
 
     // Varargs argument coercion
     for arg in tc_args.iter_mut().skip(canon_params) {
+        // All varargs arguments must be lvalues, coerce_value is necessary here
         coerce_value(arg);
 
         match &arg._type.kind {

--- a/compiler/cx-compiler-typechecker/src/casting.rs
+++ b/compiler/cx-compiler-typechecker/src/casting.rs
@@ -132,11 +132,12 @@ pub fn valid_implicit_cast(from_type: &CXType, to_type: &CXType)
             => Some(CXCastType::BitCast),
 
         (CXTypeKind::MemoryReference(inner), _)
-            if same_type(inner.as_ref(), to_type) && to_type.is_structured() => Some(CXCastType::FauxLoad),
-        (CXTypeKind::MemoryReference(inner), _) => Some(CXCastType::Load),
+            if same_type(inner.as_ref(), to_type) && to_type.is_structured() => Some(CXCastType::Reinterpret),
+        (CXTypeKind::MemoryReference(inner), _) if same_type(inner, to_type) => Some(CXCastType::Load),
 
+        (_, CXTypeKind::MemoryReference(inner)) |
         (_, CXTypeKind::PointerTo { inner_type: inner, .. })
-            if same_type(inner.as_ref(), from_type) && from_type.is_structured() => Some(CXCastType::FauxLoad),
+            if same_type(inner.as_ref(), from_type) && from_type.is_structured() => Some(CXCastType::Reinterpret),
 
         (CXTypeKind::Array { inner_type: _type, .. }, CXTypeKind::PointerTo { inner_type: inner, .. })
             if same_type(_type, inner) => Some(CXCastType::BitCast),

--- a/compiler/cx-compiler-typechecker/src/precontextualizing.rs
+++ b/compiler/cx-compiler-typechecker/src/precontextualizing.rs
@@ -216,11 +216,29 @@ pub fn precontextualize_type(
                 CXType::from(
                     CXTypeKind::Union {
                         name: name.clone(),
-                        fields,
+                        variants: fields,
                     }
                 )
             )
         }
+
+        CXNaiveTypeKind::TaggedUnion { name, variants } => {
+            let variants = variants.iter()
+                .map(|(name, variant_type)| {
+                    let variant_type = recurse_ty(variant_type)?;
+                    Some((name.clone(), variant_type))
+                })
+                .collect::<Option<Vec<_>>>()?;
+
+            Some(
+                CXType::from(
+                    CXTypeKind::TaggedUnion {
+                        name: name.clone(),
+                        variants: variants,
+                    }
+                )
+            )
+        },
     }
 }
 

--- a/compiler/cx-compiler-typechecker/src/type_mapping.rs
+++ b/compiler/cx-compiler-typechecker/src/type_mapping.rs
@@ -189,7 +189,26 @@ pub fn contextualize_type(env: &mut TCEnvironment, naive_type: &CXNaiveType) -> 
                     0,
                     CXTypeKind::Union {
                         name: name.clone(),
-                        fields,
+                        variants: fields,
+                    }
+                )
+            )
+        },
+
+        CXNaiveTypeKind::TaggedUnion { name, variants } => {
+            let variants = variants.iter()
+                .map(|(name, variant_type)| {
+                    let variant_type = contextualize_type(env, variant_type)?;
+                    Some((name.clone(), variant_type))
+                })
+                .collect::<Option<Vec<_>>>()?;
+
+            Some(
+                CXType::new(
+                    0,
+                    CXTypeKind::TaggedUnion {
+                        name: name.clone(),
+                        variants,
                     }
                 )
             )

--- a/compiler/cx-compiler-typechecker/src/typechecker.rs
+++ b/compiler/cx-compiler-typechecker/src/typechecker.rs
@@ -515,8 +515,7 @@ pub fn typecheck_expr(env: &mut TCEnvironment, expr: &CXExpr) -> Option<TCExpr> 
                     kind: TCExprKind::TypeConstructor {
                         name: name.clone(),
 
-                        union_type,
-                        variant_type,
+                        union_type, variant_type,
                         variant_index: i,
 
                         input: Box::new(inner)

--- a/compiler/cx-compiler-typechecker/src/typechecker.rs
+++ b/compiler/cx-compiler-typechecker/src/typechecker.rs
@@ -530,8 +530,7 @@ pub fn typecheck_expr(env: &mut TCEnvironment, expr: &CXExpr) -> Option<TCExpr> 
                 }
             },
             CXExprKind::SizeOf { expr } => {
-                let mut tc_expr = typecheck_expr(env, expr)?;
-                coerce_value(&mut tc_expr);
+                let tc_expr = typecheck_expr(env, expr)?;
 
                 TCExpr {
                     _type: CXType::from(CXTypeKind::Integer { signed: true, bytes: 8 }),

--- a/compiler/cx-data-ast/src/parse/ast.rs
+++ b/compiler/cx-data-ast/src/parse/ast.rs
@@ -283,5 +283,5 @@ pub enum CXCastType {
     // is stored in memory. A structured type is itself a memory reference despite this
     // dichotomy, so when attempting to convert from a mem(struct) to struct, this is
     // used to create an explicit no-op to appease the typechecker.
-    FauxLoad,
+    Reinterpret,
 }

--- a/compiler/cx-data-ast/src/parse/ast.rs
+++ b/compiler/cx-data-ast/src/parse/ast.rs
@@ -80,7 +80,9 @@ pub enum CXBinOp {
 
     Assign(Option<Box<CXBinOp>>),
 
-    Access, MethodCall, ArrayIndex
+    Access, MethodCall, ArrayIndex,
+
+    Is
 }
 
 #[derive(Debug, Clone, Readable, Writable)]
@@ -172,10 +174,17 @@ pub enum CXExprKind {
         increment: Box<CXExpr>,
         body: Box<CXExpr>
     },
+
+    Match {
+        condition: Box<CXExpr>,
+        arms: Vec<(CXExpr, CXExpr)>, // (value, block)
+        default: Option<Box<CXExpr>>
+    },
+
     Switch {
         condition: Box<CXExpr>,
         block: Vec<CXExpr>,
-        cases: Vec<(u64, usize)>,
+        cases: Vec<(u64, usize)>, // (block index, value)
         default_case: Option<usize>
     },
 
@@ -185,6 +194,11 @@ pub enum CXExprKind {
     VarDeclaration {
         type_: CXNaiveType,
         name: CXIdent
+    },
+    TypeConstructor {
+        union_name: CXIdent,
+        variant_name: CXIdent,
+        inner: Box<CXExpr>,
     },
     BinOp {
         lhs: Box<CXExpr>,
@@ -263,6 +277,7 @@ pub enum CXCastType {
     PtrToInt,
     IntToPtr,
     FunctionToPointerDecay,
+    Load,
     
     // The difference between a memory reference and a bare type is that a memory reference
     // is stored in memory. A structured type is itself a memory reference despite this

--- a/compiler/cx-data-ast/src/parse/format.rs
+++ b/compiler/cx-data-ast/src/parse/format.rs
@@ -257,7 +257,9 @@ impl Display for CXBinOp {
                 } else {
                     fwrite!(f, "=")
                 }
-            }
+            },
+
+            CXBinOp::Is         => fwrite!(f, "is"),
 
             _ => fwrite!(f, "{:?}", self)
         }

--- a/compiler/cx-data-ast/src/preparse/format.rs
+++ b/compiler/cx-data-ast/src/preparse/format.rs
@@ -32,6 +32,13 @@ impl Display for CXNaiveTypeKind {
                     .join(", ");
                 write!(f, "Union<{}> {{ {} }}", name.as_ref().map(|n| n.as_str()).unwrap_or(""), fields_str)
             },
+            CXNaiveTypeKind::TaggedUnion { name, variants } => {
+                let variants_str = variants.iter()
+                    .map(|(name, ty)| format!("{name}: {ty}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "TaggedUnion<{}> {{ {} }}", name, variants_str)
+            },
             CXNaiveTypeKind::FunctionPointer { prototype } => write!(f, "FunctionPointer({prototype})"),
         }
     }

--- a/compiler/cx-data-ast/src/preparse/naive_types.rs
+++ b/compiler/cx-data-ast/src/preparse/naive_types.rs
@@ -88,6 +88,10 @@ pub enum CXNaiveTypeKind {
         name: Option<CXIdent>,
         fields: Vec<(String, CXNaiveType)>,
     },
+    TaggedUnion {
+        name: CXIdent,
+        variants: Vec<(String, CXNaiveType)>
+    },
 
     FunctionPointer {
         prototype: Box<CXNaivePrototype>
@@ -122,8 +126,11 @@ impl CXNaiveType {
         match &self.kind {
             CXNaiveTypeKind::Identifier { name, .. } => Some(name),
             CXNaiveTypeKind::TemplatedIdentifier { name, .. } => Some(name),
+            CXNaiveTypeKind::TaggedUnion { name, .. } => Some(name),
+
             CXNaiveTypeKind::Structured { name, .. } => name.as_ref(),
             CXNaiveTypeKind::Union { name, .. } => name.as_ref(),
+
             _ => None,
         }
     }

--- a/compiler/cx-data-bytecode/src/format.rs
+++ b/compiler/cx-data-bytecode/src/format.rs
@@ -90,7 +90,7 @@ impl Display for BlockInstruction {
 impl Display for BCGlobalType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            BCGlobalType::StringLiteral(s) => write!(f, "string_literal \"{}\"", s),
+            BCGlobalType::StringLiteral(s) => write!(f, "string_literal \"{}\"", s.replace('\n', "\\n")),
             BCGlobalType::Variable { _type, initial_value } => {
                 if let Some(initial_value) = initial_value {
                     write!(f, "variable {} = {}", _type, initial_value)

--- a/compiler/cx-data-bytecode/src/types.rs
+++ b/compiler/cx-data-bytecode/src/types.rs
@@ -131,6 +131,6 @@ impl BCType {
     
     #[inline]
     pub fn is_structure(&self) -> bool {
-        matches!(self.kind, BCTypeKind::Struct { .. })
+        matches!(self.kind, BCTypeKind::Struct { .. } | BCTypeKind::Union { .. })
     }
 }

--- a/compiler/cx-data-lexer/src/token.rs
+++ b/compiler/cx-data-lexer/src/token.rs
@@ -115,7 +115,7 @@ pub enum OperatorType {
     Comma, ArrayIndex,
     Access, ScopeRes,
     
-    Move
+    Move, Is
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -126,7 +126,9 @@ pub enum PunctuatorType {
     Semicolon,
     Ellipsis,
     Colon, Period,
-    QuestionMark
+    QuestionMark,
+
+    ThickArrow /* (=>) */
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -147,7 +149,7 @@ pub enum KeywordType {
 
     // CX Specific
     Import, Defer, Strong, Weak, New, 
-    Template, Type
+    Template, Type, Class, Match
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -218,6 +220,11 @@ impl TokenKind {
 
             "template" => TokenKind::Keyword(KeywordType::Template),
             "type" => TokenKind::Keyword(KeywordType::Type),
+
+            "class" => TokenKind::Keyword(KeywordType::Class),
+
+            "match" => TokenKind::Keyword(KeywordType::Match),
+            "is"    => TokenKind::Operator(OperatorType::Is),
 
             _ => TokenKind::Identifier(str),
         }

--- a/compiler/cx-data-typechecker/src/ast.rs
+++ b/compiler/cx-data-typechecker/src/ast.rs
@@ -160,11 +160,27 @@ pub enum TCExprKind {
         body: Box<TCExpr>,
     },
 
-    Switch {
+    CSwitch {
         condition: Box<TCExpr>,
         block: Vec<TCExpr>,
         cases: Vec<(u64, usize)>, // (case value, index of the case body)
         default_case: Option<usize>,
+    },
+
+    Match {
+        condition: Box<TCExpr>,
+        cases: Vec<TCTagMatch>, // (tag value, case body)
+        default_case: Option<Box<TCExpr>>,
+    },
+
+    ConstructorMatchIs {
+        expr: Box<TCExpr>,
+
+        union_type: CXType,
+        variant_type: CXType,
+        variant_tag: u64,
+
+        var_name: CXIdent
     },
 
     ImplicitLoad {
@@ -201,6 +217,16 @@ pub enum TCExprKind {
         indices: Vec<TCInitIndex>,
     },
 
+    TypeConstructor {
+        name: CXIdent,
+
+        union_type: CXType,
+        variant_type: CXType,
+        variant_index: usize,
+
+        input: Box<TCExpr>
+    },
+
     Break,
     Continue,
 
@@ -215,4 +241,12 @@ pub struct TCInitIndex {
     pub name: Option<String>,
     pub value: TCExpr,
     pub index: usize,
+}
+
+#[derive(Debug, Clone, Readable, Writable)]
+pub struct TCTagMatch {
+    pub tag_value: u64,
+    pub body: Box<TCExpr>,
+    pub variant_type: CXType,
+    pub instance_name: CXIdent,
 }

--- a/compiler/cx-data-typechecker/src/format.rs
+++ b/compiler/cx-data-typechecker/src/format.rs
@@ -44,7 +44,7 @@ impl Display for CXTypeKind {
 
                 write!(f, "struct {name_str} {{ {field_strs} }}")
             },
-            CXTypeKind::Union { fields, name } => {
+            CXTypeKind::Union { variants: fields, name } => {
                 let field_strs = fields.iter()
                     .map(|(name, type_)| format!("{name}: {type_}"))
                     .collect::<Vec<_>>()
@@ -56,6 +56,14 @@ impl Display for CXTypeKind {
                 };
 
                 write!(f, "union {name_str} {{ {field_strs} }}")
+            },
+            CXTypeKind::TaggedUnion { variants: fields, name } => {
+                let variant_strs = fields.iter()
+                    .map(|(name, type_)| format!("{name}: {type_}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                write!(f, "tagged union {name} {{ {variant_strs} }}")
             },
             CXTypeKind::Unit => write!(f, "()"),
             CXTypeKind::PointerTo { inner_type: inner, weak: explicitly_weak, nullable, sizeless_array } => {

--- a/compiler/cx-data-typechecker/src/format.rs
+++ b/compiler/cx-data-typechecker/src/format.rs
@@ -1,120 +1,347 @@
-use std::fmt::{Display, Formatter};
+use std::fmt::{Display, Formatter, Result};
+use super::ast::*;
 use crate::cx_types::{CXFunctionPrototype, CXParameter, CXType, CXTypeKind};
+use cx_data_ast::parse::ast::{CXBinOp, CXUnOp, CXCastType};
+use cx_util::identifier::CXIdent;
 
-impl Display for CXFunctionPrototype {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "fn {}({}) -> {}",
-               self.name.as_string(),
-               self.params.iter().map(|p| format!("{p}")).collect::<Vec<_>>().join(", "),
-               self.return_type
-        )
+// Helper struct for indented formatting of TCExpr
+struct TCExprFormatter<'a> {
+    expr: &'a TCExpr,
+    depth: usize,
+}
+
+impl<'a> TCExprFormatter<'a> {
+    fn new(expr: &'a TCExpr, depth: usize) -> Self {
+        Self { expr, depth }
+    }
+
+    fn indent(&self, f: &mut Formatter<'_>) -> Result {
+        for _ in 0..self.depth {
+            write!(f, "  ")?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for TCAST {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        writeln!(f, "TCAST for file: {}", self.source_file)?;
+        if !self.global_variables.is_empty() {
+            writeln!(f, "\n-- Global Variables --")?;
+            for global in &self.global_variables {
+                writeln!(f, "{}", global)?;
+            }
+        }
+        if !self.function_defs.is_empty() {
+            writeln!(f, "\n-- Function Definitions --")?;
+            for func in &self.function_defs {
+                writeln!(f, "{}", func)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Display for TCGlobalVariable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            TCGlobalVariable::UnaddressableConstant { name, val } => {
+                write!(f, "UnaddressableConstant {} = {}", name, val)
+            }
+            TCGlobalVariable::StringLiteral { name, value } => {
+                write!(f, "StringLiteral {} = \"{}\"", name, value.escape_default())
+            }
+            TCGlobalVariable::Variable { name, _type, initializer } => {
+                write!(f, "Variable {} : {}", name, _type)?;
+                if let Some(init) = initializer {
+                    write!(f, " = {}", init)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Display for TCFunctionDef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        writeln!(f, "FunctionDef {} {{", self.prototype)?;
+        write!(f, "{}", TCExprFormatter::new(&self.body, 1))?;
+        writeln!(f, "}}")?;
+        Ok(())
+    }
+}
+
+impl Display for TCExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        TCExprFormatter::new(self, 0).fmt(f)
+    }
+}
+
+impl<'a> Display for TCExprFormatter<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        self.indent(f)?;
+        match &self.expr.kind {
+            TCExprKind::Taken => writeln!(f, "Taken {}", self.expr._type)?,
+            TCExprKind::Unit => writeln!(f, "Unit {}", self.expr._type)?,
+            TCExprKind::Block { statements } => {
+                writeln!(f, "Block {{{}}}", self.expr._type)?;
+                for stmt in statements {
+                    TCExprFormatter::new(stmt, self.depth + 1).fmt(f)?;
+                }
+                self.indent(f)?;
+                writeln!(f, "}}")?;
+            }
+            TCExprKind::IntLiteral { value } => {
+                writeln!(f, "IntLiteral {} {}", value, self.expr._type)?;
+            }
+            TCExprKind::FloatLiteral { value } => {
+                writeln!(f, "FloatLiteral {} {}", value, self.expr._type)?;
+            }
+            TCExprKind::SizeOf { _type } => {
+                writeln!(f, "SizeOf {} {}", _type, self.expr._type)?;
+            }
+            TCExprKind::VariableDeclaration { type_, name } => {
+                writeln!(f, "VariableDeclaration {} {} {}", name, type_, self.expr._type)?;
+            }
+            TCExprKind::GlobalVariableReference { name } => {
+                writeln!(f, "GlobalVariableReference {} {}", name, self.expr._type)?;
+            }
+            TCExprKind::VariableReference { name } => {
+                writeln!(f, "VariableReference {} {}", name, self.expr._type)?;
+            }
+            TCExprKind::FunctionReference { name } => {
+                writeln!(f, "FunctionReference {} {}", name, self.expr._type)?;
+            }
+            TCExprKind::MemberFunctionReference { target, mangled_name } => {
+                writeln!(f, "MemberFunctionReference {} {}", mangled_name, self.expr._type)?;
+                TCExprFormatter::new(target, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::FunctionCall { function, arguments, direct_call } => {
+                writeln!(f, "FunctionCall (direct: {}) {}", direct_call, self.expr._type)?;
+                TCExprFormatter::new(function, self.depth + 1).fmt(f)?;
+                for arg in arguments {
+                    TCExprFormatter::new(arg, self.depth + 1).fmt(f)?;
+                }
+            }
+            TCExprKind::Access { target, field } => {
+                writeln!(f, "Access .{} {}", field, self.expr._type)?;
+                TCExprFormatter::new(target, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::Assignment { target, value, additional_op } => {
+                if let Some(op) = additional_op {
+                    writeln!(f, "Assignment (op={:?}) {}", op, self.expr._type)?;
+                } else {
+                    writeln!(f, "Assignment {}", self.expr._type)?;
+                }
+                TCExprFormatter::new(target, self.depth + 1).fmt(f)?;
+                TCExprFormatter::new(value, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::BinOp { lhs, rhs, op } => {
+                writeln!(f, "BinOp {:?} {}", op, self.expr._type)?;
+                TCExprFormatter::new(lhs, self.depth + 1).fmt(f)?;
+                TCExprFormatter::new(rhs, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::UnOp { operand, operator } => {
+                writeln!(f, "UnOp {:?} {}", operator, self.expr._type)?;
+                TCExprFormatter::new(operand, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::If { condition, then_branch, else_branch } => {
+                writeln!(f, "If {}", self.expr._type)?;
+                TCExprFormatter::new(condition, self.depth + 1).fmt(f)?;
+                TCExprFormatter::new(then_branch, self.depth + 1).fmt(f)?;
+                if let Some(else_b) = else_branch {
+                    TCExprFormatter::new(else_b, self.depth + 1).fmt(f)?;
+                }
+            }
+            TCExprKind::While { condition, body, pre_eval } => {
+                writeln!(f, "While (pre_eval: {}) {}", pre_eval, self.expr._type)?;
+                TCExprFormatter::new(condition, self.depth + 1).fmt(f)?;
+                TCExprFormatter::new(body, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::For { init, condition, increment, body } => {
+                writeln!(f, "For {}", self.expr._type)?;
+                TCExprFormatter::new(init, self.depth + 1).fmt(f)?;
+                TCExprFormatter::new(condition, self.depth + 1).fmt(f)?;
+                TCExprFormatter::new(increment, self.depth + 1).fmt(f)?;
+                TCExprFormatter::new(body, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::CSwitch { condition, block, cases, default_case } => {
+                writeln!(f, "CSwitch cases: {:?}, default: {:?} {}", cases, default_case, self.expr._type)?;
+                TCExprFormatter::new(condition, self.depth + 1).fmt(f)?;
+                for stmt in block {
+                    TCExprFormatter::new(stmt, self.depth + 1).fmt(f)?;
+                }
+            }
+            TCExprKind::Match { condition, cases, default_case } => {
+                writeln!(f, "Match {}", self.expr._type)?;
+                TCExprFormatter::new(condition, self.depth + 1).fmt(f)?;
+                for case_ in cases {
+                    self.indent(f)?;
+                    writeln!(f, "{}", case_)?;
+                    TCExprFormatter::new(&case_.body, self.depth + 1).fmt(f)?;
+                }
+                if let Some(default_b) = default_case {
+                    self.indent(f)?;
+                    writeln!(f, "Default:")?;
+                    TCExprFormatter::new(default_b, self.depth + 1).fmt(f)?;
+                }
+            }
+            TCExprKind::ConstructorMatchIs { expr, union_type, var_name, .. } => {
+                writeln!(f, "ConstructorMatchIs is {}::{} {}", union_type, var_name, self.expr._type)?;
+                TCExprFormatter::new(expr, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::ImplicitLoad { operand } => {
+                writeln!(f, "ImplicitLoad {}", self.expr._type)?;
+                TCExprFormatter::new(operand, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::TemporaryBuffer { _type } => {
+                writeln!(f, "TemporaryBuffer {} {}", _type, self.expr._type)?;
+            }
+            TCExprKind::Coercion { operand, cast_type } => {
+                writeln!(f, "Coercion to {:?} {}", cast_type, self.expr._type)?;
+                TCExprFormatter::new(operand, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::Defer { operand } => {
+                writeln!(f, "Defer {}", self.expr._type)?;
+                TCExprFormatter::new(operand, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::New { _type, array_length } => {
+                if let Some(len) = array_length {
+                    writeln!(f, "New[] {} {}", _type, self.expr._type)?;
+                    TCExprFormatter::new(len, self.depth + 1).fmt(f)?;
+                } else {
+                    writeln!(f, "New {} {}", _type, self.expr._type)?;
+                }
+            }
+            TCExprKind::Move { operand } => {
+                writeln!(f, "Move {}", self.expr._type)?;
+                TCExprFormatter::new(operand, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::Return { value } => {
+                writeln!(f, "Return {}", self.expr._type)?;
+                if let Some(val) = value {
+                    TCExprFormatter::new(val, self.depth + 1).fmt(f)?;
+                }
+            }
+            TCExprKind::InitializerList { indices } => {
+                writeln!(f, "InitializerList {}", self.expr._type)?;
+                for index in indices {
+                    TCInitIndexFormatter::new(index, self.depth + 1).fmt(f)?;
+                }
+            }
+            TCExprKind::TypeConstructor { name, union_type, input, .. } => {
+                writeln!(f, "TypeConstructor {}::{} {}", union_type, name, self.expr._type)?;
+                TCExprFormatter::new(input, self.depth + 1).fmt(f)?;
+            }
+            TCExprKind::Break => writeln!(f, "Break {}", self.expr._type)?,
+            TCExprKind::Continue => writeln!(f, "Continue {}", self.expr._type)?,
+            TCExprKind::DeconstructObject { variable_name, variable_type } => {
+                writeln!(f, "DeconstructObject {} {} {}", variable_name, variable_type, self.expr._type)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Display for TCTagMatch {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "case tag {} as {}", self.tag_value, self.instance_name)?;
+        Ok(())
+    }
+}
+
+struct TCInitIndexFormatter<'a> {
+    index: &'a TCInitIndex,
+    depth: usize,
+}
+
+impl<'a> TCInitIndexFormatter<'a> {
+    fn new(index: &'a TCInitIndex, depth: usize) -> Self {
+        Self { index, depth }
+    }
+
+    fn indent(&self, f: &mut Formatter<'_>) -> Result {
+        for _ in 0..self.depth {
+            write!(f, "  ")?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> Display for TCInitIndexFormatter<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        self.indent(f)?;
+        if let Some(name) = &self.index.name {
+            writeln!(f, ".{name} = ")?;
+        } else {
+            writeln!(f, "[{}] = ", self.index.index)?;
+        }
+        TCExprFormatter::new(&self.index.value, self.depth + 1).fmt(f)?;
+        Ok(())
     }
 }
 
 impl Display for CXType {
-    
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        if self.specifiers != 0 {
+            // Not all specifiers may be covered, so this is a fallback
+            write!(f, "specifiers: {} ", self.specifiers)?;
+        }
         write!(f, "{}", self.kind)
     }
 }
 
 impl Display for CXTypeKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             CXTypeKind::Integer { bytes, signed } => {
-                let signed_str = if *signed { "i" } else { "u" };
-                let signed_bytes = *bytes * 8;
-                write!(f, "{signed_str}{signed_bytes}")
-            },
-            CXTypeKind::Float { bytes } => {
-                let float_bytes = *bytes * 8;
-                write!(f, "f{float_bytes}")
-            },
+                write!(f, "{}{}", if *signed { "i" } else { "u" }, bytes * 8)
+            }
+            CXTypeKind::Float { bytes } => write!(f, "f{}", bytes * 8),
             CXTypeKind::Bool => write!(f, "bool"),
-            CXTypeKind::Structured { fields, base_identifier, .. } => {
-                let field_strs = fields.iter()
-                    .map(|(name, type_)| format!("{name}: {type_}"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let name_str = if let Some(base_identifier) = base_identifier {
-                    format!("{base_identifier} ")
-                } else {
-                    "".to_string()
-                };
-
-                write!(f, "struct {name_str} {{ {field_strs} }}")
-            },
-            CXTypeKind::Union { variants: fields, name } => {
-                let field_strs = fields.iter()
-                    .map(|(name, type_)| format!("{name}: {type_}"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let name_str = if let Some(name) = name {
-                    format!("{name} ")
-                } else {
-                    "".to_string()
-                };
-
-                write!(f, "union {name_str} {{ {field_strs} }}")
-            },
-            CXTypeKind::TaggedUnion { variants: fields, name } => {
-                let variant_strs = fields.iter()
-                    .map(|(name, type_)| format!("{name}: {type_}"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                write!(f, "tagged union {name} {{ {variant_strs} }}")
-            },
+            CXTypeKind::Structured { name, .. } => {
+                write!(f, "struct {}", name.as_ref().map(|n| n.as_str()).unwrap_or("<anonymous>"))
+            }
+            CXTypeKind::Union { name, .. } => {
+                write!(f, "union {}", name.as_ref().map(|n| n.as_str()).unwrap_or("<anonymous>"))
+            }
+            CXTypeKind::TaggedUnion { name, .. } => {
+                write!(f, "tagged union {}", name)
+            }
             CXTypeKind::Unit => write!(f, "()"),
-            CXTypeKind::PointerTo { inner_type: inner, weak: explicitly_weak, nullable, sizeless_array } => {
-                write!(f, "{inner} ")?;
-
-                if *explicitly_weak {
-                    write!(f, "weak")?;
-                }
-
-                if *sizeless_array {
-                    write!(f, "[]")?;
-                } else {
-                    write!(f, "*")?;
-                }
-
-                if !*nullable {
-                    write!(f, " (nonnull)")
-                } else {
-                    Ok(())
-                }
-            },
-            CXTypeKind::StrongPointer { inner_type: inner, is_array } => {
-                write!(f, "{inner} strong")?;
-                if *is_array {
-                    write!(f, "[]")
-                } else {
-                    write!(f, "*")
-                }
-            },
-            CXTypeKind::Array { size, inner_type: _type } => {
-                write!(f, "[{size}; {_type}]")
-            },
-            CXTypeKind::VariableLengthArray { _type, .. } => {
-                write!(f, "[{_type}; variable]")
-            },
-            CXTypeKind::Opaque { name, size } => {
-                write!(f, "OPAQUE_{size}(\"{name}\")")
-            },
-            CXTypeKind::Function { prototype } => {
-                write!(f, "{prototype}")
-            },
-            CXTypeKind::MemoryReference(inner) => {
-                write!(f, "&{inner}")
-            },
+            CXTypeKind::StrongPointer { inner_type, .. } => write!(f, "@{}", inner_type),
+            CXTypeKind::PointerTo { inner_type, .. } => write!(f, "*{}", inner_type),
+            CXTypeKind::MemoryReference(inner) => write!(f, "&{}", inner),
+            CXTypeKind::Array { size, inner_type } => write!(f, "[{}; {}]", inner_type, size),
+            CXTypeKind::VariableLengthArray { _type, .. } => write!(f, "[{}..]", _type),
+            CXTypeKind::Opaque { name, .. } => write!(f, "opaque {}", name),
+            CXTypeKind::Function { prototype } => write!(f, "fn {}", prototype),
         }
     }
 }
 
+impl Display for CXFunctionPrototype {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}(", self.name)?;
+        for (i, param) in self.params.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", param)?;
+        }
+        if self.var_args {
+            if !self.params.is_empty() {
+                write!(f, ", ")?;
+            }
+            write!(f, "...")?;
+        }
+        write!(f, ") -> {}", self.return_type)
+    }
+}
 
 impl Display for CXParameter {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if let Some(name) = &self.name {
             write!(f, "{}: {}", name, self._type)
         } else {

--- a/compiler/cx-data-typechecker/src/lib.rs
+++ b/compiler/cx-data-typechecker/src/lib.rs
@@ -2,7 +2,7 @@ pub mod ast;
 pub mod cx_types;
 pub mod intrinsic_types;
 
-mod format;
+pub mod format;
 
 use std::collections::{HashMap, HashSet};
 use speedy::{Readable, Writable};

--- a/compiler/cx-pipeline/src/scheduler.rs
+++ b/compiler/cx-pipeline/src/scheduler.rs
@@ -358,7 +358,7 @@ pub(crate) fn perform_job(
             };
 
             if !job.unit.is_std_lib() {
-                dump_data(&format!("{:#?}", tc_ast));
+                dump_data(&tc_ast);
             }
 
             context.module_db.typechecked_ast.insert(job.unit.clone(), tc_ast);

--- a/lib/libc/stdlib.h
+++ b/lib/libc/stdlib.h
@@ -11,3 +11,5 @@ void free(void* ptr);
 int atoi(const char *str);
 int rand();
 int srand(u32 seed);
+
+void exit(int status);

--- a/tests/cases/sum_type.cx
+++ b/tests/cases/sum_type.cx
@@ -14,9 +14,10 @@ Output generate_output(int i) {
         case 1: return Output::fp(3.14);
         case 2: return Output::string("Hello, World!");
         case 3: return Output::data({ 1, 2.0, 'c' });
-        default: exit(1);
+        default:
+            printf("Invalid input, returning integer 0\n");
+            break;
     }
-
     return Output::integer(0); // Fallback, should never reach here
 }
 

--- a/tests/cases/sum_type.cx
+++ b/tests/cases/sum_type.cx
@@ -1,0 +1,55 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+union class Output {
+    integer :: int,
+    fp      :: double,
+    string  :: const char*,
+    data    :: struct { int a; double b; char c; }
+};
+
+Output generate_output(int i) {
+    switch (i) {
+        case 0: return Output::integer(42);
+        case 1: return Output::fp(3.14);
+        case 2: return Output::string("Hello, World!");
+        case 3: return Output::data({ 1, 2.0, 'c' });
+        default: exit(1);
+    }
+
+    return Output::integer(0); // Fallback, should never reach here
+}
+
+void print_output(Output out) {
+    match (out) {
+        Output::integer(i) => printf("Integer: %d\n", i);
+        Output::fp(d) => printf("Float: %f\n", d);
+        Output::string(s) => printf("String: %s\n", s);
+        Output::data(data) => printf("Data: a=%d, b=%f, c=%c\n", data.a, data.b, data.c);
+        default => printf("Unknown type\n");
+    }
+}
+
+int main() {
+    Output out1 = generate_output(0);
+    Output out2 = generate_output(1);
+    Output out3 = generate_output(2);
+    Output out4 = generate_output(3);
+
+    if (out3 is Output::string(s)) {
+        printf("Extracted string: %s\n", s);
+    } else {
+        printf("Not a string\n");
+    }
+
+    if (out2 is Output::string(s)) {
+        printf("Extracted string: %s\n", s);
+    } else {
+        printf("Not a string\n");
+    }
+
+    print_output(out1);
+    print_output(out2);
+    print_output(out3);
+    print_output(out4);
+}

--- a/tests/cases/sum_type.cx-output
+++ b/tests/cases/sum_type.cx-output
@@ -1,0 +1,6 @@
+Extracted string: Hello, World!
+Not a string
+Integer: 42
+Float: 3.140000
+String: Hello, World!
+Data: a=1, b=2.000000, c=c

--- a/tests/sum_type.cx-output
+++ b/tests/sum_type.cx-output
@@ -1,0 +1,4 @@
+Integer: 42
+Float: 3.140000
+String: Hello, World!
+Data: a=1, b=2.000000, c=c

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -36,7 +36,8 @@ test_files!(
     vector,
     templated_destructor,
     basic_global_variable,
-    global_in_template
+    global_in_template,
+    sum_type
 );
 
 #[ctor::ctor]


### PR DESCRIPTION
Tagged Unions / Sum Types are declared using 'union class' instead of a pure union. Tagged Unions use a slightly different syntax, where each variant must be declared with '[variant_name] :: [variant_type]' rather than with standard initialization syntax to help with readability.

AI Summary:
This pull request introduces significant improvements and new features to the compiler's AST parsing, type handling, and backend code generation. The most notable changes are the addition of tagged union parsing and match expressions to the language, enhancements to union type representation in LLVM backend, and improvements to assignment and instruction handling in the bytecode compiler. These changes collectively improve language expressiveness and backend robustness.

**Language Feature Additions**

* Added support for parsing tagged unions (`union class`) and their variants in the AST preparse phase, enabling more expressive sum types. [[1]](diffhunk://#diff-68d15a12bcc81bff9ae0367a31d32d04b277fae07da1991118dd774e2261146fR63-R106) [[2]](diffhunk://#diff-68d15a12bcc81bff9ae0367a31d32d04b277fae07da1991118dd774e2261146fL74-R130)
* Implemented parsing for `match` expressions, including match arms and default cases, allowing pattern matching in the language. [[1]](diffhunk://#diff-f56a919643a9074d337f14f44ab3c147ea3bb7e3e035587bcaf747b9159849ebR22-L31) [[2]](diffhunk://#diff-f56a919643a9074d337f14f44ab3c147ea3bb7e3e035587bcaf747b9159849ebR421-R460)

**AST and Operator Improvements**

* Added support for the `is` binary operator with correct precedence and parsing, improving type checking and pattern matching capabilities. [[1]](diffhunk://#diff-f260b8267d4a3a379758bedc920e7660104f51ff5608cff2cd36928e43bed769L34-R34) [[2]](diffhunk://#diff-f260b8267d4a3a379758bedc920e7660104f51ff5608cff2cd36928e43bed769R160-R161)

**LLVM Backend Enhancements**

* Changed union type representation in the LLVM backend to use a byte array of the union's fixed size, improving compatibility and simplifying code generation for unions.
* Improved memory store logic by using the type's fixed size for memory operations instead of relying on LLVM type introspection.

**Bytecode Compiler Improvements**

* Added an `assign_value` routine for assignment operations and improved block termination handling to avoid generating instructions after block termination. [[1]](diffhunk://#diff-f38276cca1bfb91ad8f4f1f5a1006c247805b5a323a594eaab8cae7184dd152eR165-R181) [[2]](diffhunk://#diff-afbcaaa8747b497140bc989156b07c6735c9d0c188275ba9f1c090387dd32a1bR187-R190) [[3]](diffhunk://#diff-afbcaaa8747b497140bc989156b07c6735c9d0c188275ba9f1c090387dd32a1bR213-R220)

**Debugging and Logging**

* Added debug output for instruction generation in the LLVM and Cranelift backends to aid troubleshooting and development. [[1]](diffhunk://#diff-5e1b403d250ec1c9447e6d3f1482afc69dcb8f4920ecab8d408fa263d322ea5aR9) [[2]](diffhunk://#diff-5e1b403d250ec1c9447e6d3f1482afc69dcb8f4920ecab8d408fa263d322ea5aR106-R107) [[3]](diffhunk://#diff-4ca9aabce8e7f8a53026e0bc5ca1e933c703d3d83ed78f67fc03bcee755d58b3R281-R282)