### PR TITLE
fix(MIR + BC): Two very simple but effective ways to reduce local memory allocations

### DIFF
--- a/compiler/cx-ast/src/ast.rs
+++ b/compiler/cx-ast/src/ast.rs
@@ -213,6 +213,7 @@ pub enum CXExprKind {
     VarDeclaration {
         _type: CXType,
         name: CXIdent,
+        initial_value: Option<Box<CXExpr>>,
     },
     TypeConstructor {
         union_name: CXIdent,

--- a/compiler/cx-ast/src/format.rs
+++ b/compiler/cx-ast/src/format.rs
@@ -157,8 +157,13 @@ impl<'a> Display for CXExprFormatter<'a> {
 
                 writeln!(f, "TemplatedIdentifier {}<{}>", fn_name, arg_string)
             }
-            CXExprKind::VarDeclaration { name, _type } => {
-                writeln!(f, "VarDeclaration {}: {}", name, _type)
+            CXExprKind::VarDeclaration {
+                name,
+                _type,
+                initial_value,
+            } => {
+                let init_str = if initial_value.is_some() { " = <init>" } else { "" };
+                writeln!(f, "VarDeclaration {}: {}{}", name, _type, init_str)
             }
             CXExprKind::IntLiteral { val, .. } => writeln!(f, "IntLiteral {}", val),
             CXExprKind::FloatLiteral { val, .. } => writeln!(f, "FloatLiteral {}", val),

--- a/compiler/cx-mir-lowering/src/mir_lowering/expressions.rs
+++ b/compiler/cx-mir-lowering/src/mir_lowering/expressions.rs
@@ -129,18 +129,76 @@ pub fn lower_expression(builder: &mut LMIRBuilder, expr: &MIRExpression) -> CXRe
 
         MIRExpressionKind::Typechange(inner) => lower_expression(builder, inner),
 
-        MIRExpressionKind::CreateStackVariable { name, _type } => {
+        MIRExpressionKind::CreateStackVariable {
+            name,
+            _type,
+            initial_value,
+        } => {
             let bc_type = builder.convert_cx_type(_type);
 
-            let result = builder.add_new_instruction(
-                LMIRInstructionKind::Allocate {
-                    alignment: bc_type.alignment(),
-                    _type: bc_type,
-                },
-                LMIRType::default_pointer(),
-                true,
-            )?;
+            let result = if let Some(initial_value) = initial_value {
+                if _type.is_memory_resident() {
+                    // OPTIMIZATION: The initial value expression returns a pointer to its buffer.
+                    // Alias that buffer as the variable's buffer - no allocation or copy needed.
+                    let bc_iv = lower_expression(builder, initial_value)?;
 
+                    if let Some(name) = name {
+                        builder.insert_symbol(name.clone(), bc_iv.clone());
+
+                        if let LMIRValue::Register { register, .. } = &bc_iv {
+                            if needs_deconstruction(builder, _type) {
+                                let liveness = allocate_liveness_variable(builder)?;
+                                let ptr_val = LMIRValue::Register {
+                                    register: register.clone(),
+                                    _type: LMIRType::default_pointer(),
+                                };
+
+                                builder.add_liveness_mapping(
+                                    name.to_string(),
+                                    ptr_val,
+                                    liveness,
+                                    _type.clone(),
+                                );
+                            }
+                        }
+                    }
+
+                    return Ok(bc_iv);
+                } else {
+                    // Primitive type - allocate and store the value
+                    let alloc = builder.add_new_instruction(
+                        LMIRInstructionKind::Allocate {
+                            alignment: bc_type.alignment(),
+                            _type: bc_type.clone(),
+                        },
+                        LMIRType::default_pointer(),
+                        true,
+                    )?;
+                    let init_val = lower_expression(builder, initial_value)?;
+                    builder.add_new_instruction(
+                        LMIRInstructionKind::Store {
+                            memory: alloc.clone(),
+                            value: init_val,
+                            _type: bc_type.clone(),
+                        },
+                        LMIRType::unit(),
+                        false,
+                    )?;
+                    alloc
+                }
+            } else {
+                // No initialization - just allocate
+                builder.add_new_instruction(
+                    LMIRInstructionKind::Allocate {
+                        alignment: bc_type.alignment(),
+                        _type: bc_type,
+                    },
+                    LMIRType::default_pointer(),
+                    true,
+                )?
+            };
+
+            // Symbol table insertion (for non-memory-resident with init, or no init cases)
             if let Some(name) = name {
                 builder.insert_symbol(name.clone(), result.clone());
 

--- a/compiler/cx-mir/src/mir/expression.rs
+++ b/compiler/cx-mir/src/mir/expression.rs
@@ -63,6 +63,7 @@ pub enum MIRExpressionKind {
     CreateStackVariable {
         name: Option<CXIdent>,
         _type: MIRType,
+        initial_value: Option<Box<MIRExpression>>,
     },
     CopyRegion {
         source: Box<MIRExpression>,

--- a/compiler/cx-mir/src/mir/format.rs
+++ b/compiler/cx-mir/src/mir/format.rs
@@ -213,12 +213,17 @@ impl<'a> Display for MIRExpressionFormatter<'a> {
                 writeln!(f, "Typechange <'{}>", self.expr._type)?;
                 MIRExpressionFormatter::new(expression, self.depth + 1).fmt(f)
             }
-            MIRExpressionKind::CreateStackVariable { name, _type } => {
+            MIRExpressionKind::CreateStackVariable {
+                name,
+                _type,
+                initial_value,
+            } => {
                 let name_str = name.as_ref().map(|t| t.as_str()).unwrap_or("(unnamed)");
+                let init_str = if initial_value.is_some() { " = <init>" } else { "" };
                 writeln!(
                     f,
-                    "CreateStackVariable {}: {} <'{}>",
-                    name_str, _type, self.expr._type
+                    "CreateStackVariable {}: {}{} <'{}>",
+                    name_str, _type, init_str, self.expr._type
                 )
             }
             MIRExpressionKind::CopyRegion { source, _type } => {

--- a/compiler/cx-parsing/src/parse/expressions.rs
+++ b/compiler/cx-parsing/src/parse/expressions.rs
@@ -114,8 +114,18 @@ pub(crate) fn parse_declaration(data: &mut ParserData) -> CXResult<CXExpr> {
         };
 
         if let Some(name) = name {
+            // Check for initializer after variable name
+            let initial_value = if try_next!(data.tokens, TokenKind::Assignment(None)) {
+                data.change_comma_mode(false);
+                let init_expr = parse_expr(data)?;
+                data.pop_comma_mode();
+                Some(Box::new(init_expr))
+            } else {
+                None
+            };
+
             decls.push(
-                CXExprKind::VarDeclaration { _type, name }
+                CXExprKind::VarDeclaration { _type, name, initial_value }
                     .into_expr(start_index, data.tokens.index),
             );
         } else {
@@ -350,6 +360,7 @@ pub(crate) fn parse_expr_val(
                         CXExprKind::VarDeclaration {
                             name: CXIdent::new("__internal_sizeof_dummy_decl"),
                             _type,
+                            initial_value: None,
                         }
                         .into_expr(start_index, data.tokens.index),
                     ),

--- a/compiler/cx-typechecker/src/type_checking/typechecker.rs
+++ b/compiler/cx-typechecker/src/type_checking/typechecker.rs
@@ -102,14 +102,29 @@ pub fn typecheck_expr_inner(
             })
         }
 
-        CXExprKind::VarDeclaration { _type, name } => {
+        CXExprKind::VarDeclaration {
+            _type,
+            name,
+            initial_value,
+        } => {
             let _type = env.complete_type(base_data, _type)?;
             let mem_type = _type.clone().mem_ref_to();
+
+            // Typecheck initial value if present
+            let mir_initial_value = match initial_value {
+                Some(init_expr) => {
+                    let init_tc = typecheck_expr(env, base_data, init_expr, Some(&_type))?;
+                    let init_tc = implicit_cast(env, expr, init_tc.into_expression(), &_type)?;
+                    Some(Box::new(init_tc))
+                }
+                None => None,
+            };
 
             let allocation = MIRExpression {
                 kind: MIRExpressionKind::CreateStackVariable {
                     name: Some(name.clone()),
                     _type: _type.clone(),
+                    initial_value: mir_initial_value,
                 },
                 _type: mem_type.clone(),
             };
@@ -152,7 +167,8 @@ pub fn typecheck_expr_inner(
             // These [for now], are only for functions, as templated type identifiers can only appear
             // in CXType contexts.
 
-            let function = env.get_standard_function(base_data, expr, name, Some(template_input))?;
+            let function =
+                env.get_standard_function(base_data, expr, name, Some(template_input))?;
 
             TypecheckResult::expr2(MIRExpression {
                 kind: MIRExpressionKind::FunctionReference {
@@ -293,10 +309,31 @@ pub fn typecheck_expr_inner(
                 .map(|v| typecheck_expr(env, base_data, v, Some(&return_type)))
                 .transpose()?;
 
-            let value = match (&value_tc, &return_type) {
-                (Some(some_value), return_type) if !return_type.is_unit() => Some(Box::new(
-                    implicit_cast(env, expr, some_value.clone().into_expression(), return_type)?,
-                )),
+            let value = match (value_tc, &return_type) {
+                (Some(mut some_value), return_type) if !return_type.is_unit() => {
+                    let mut _ty = some_value.expression._type.clone();
+
+                    // If we are returning a copyable struct T, and we are given a &T, we can inline a bit
+                    // of the implicit cast behavior here so instead of creating a temporary buffer to copy
+                    // into, and then memcpy from that buffer, we can just "unsafely" coerce the &T to a T
+                    // so we will induce in effect just a direct memcpy from the source T to the return buffer.
+                    if let Some(inner) = _ty.mem_ref_inner()
+                        && env.is_copyable(inner)
+                        && return_type.is_memory_resident()
+                    {
+                        some_value = TypecheckResult::expr(
+                            inner.clone(),
+                            MIRExpressionKind::Typechange(Box::new(some_value.into_expression())),
+                        );
+                    }
+
+                    Some(Box::new(implicit_cast(
+                        env,
+                        expr,
+                        some_value.into_expression(),
+                        return_type,
+                    )?))
+                }
 
                 (None, _) if return_type.is_unit() => None,
 
@@ -667,6 +704,7 @@ pub fn typecheck_expr_inner(
                 MIRExpressionKind::CreateStackVariable {
                     name: None,
                     _type: union_type.clone(),
+                    initial_value: None,
                 },
             );
 


### PR DESCRIPTION
1. For some expression like ```struct data s = create_s()```, instead of creating a naive assignment tree, evaluating the LHS and the RHS functions with their own buffers and copy over, create a single CREATESTACKVAR (data) (s) = DIRECTCALL "create_s" tree that allows CREATESTACKVAR to have the awareness that if its RHS is a memory_resident, it need not allocate its own buffer, it can simply take over the buffer it is being given.

2. For some return function, if we are returning a memory resident type T and the return node is given a &T, what would happen before is an implicit copy would be induced to convert from &T -> T, and then the copied buffer would be memcpy'd into the implicit return buffer. Now what happens is we acknowledge that copyable T's can be "unsafely" bitcasted from &T to T, as the resulting behavior is the same, the T value is copied, but instead of needing a new implicit buffer we just copy it directly to its intended destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Variable declarations now support optional initialization expressions, allowing developers to initialize variables directly at the point of declaration. The compiler provides comprehensive type validation, automatic casting, and optimized code generation for all variable types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->